### PR TITLE
Add unregister method

### DIFF
--- a/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
+++ b/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
@@ -155,7 +155,7 @@ public class MetricManagerTest
                 consumer.MetricFilter.Add(metric.Item1);
             }
 
-            MetricManager.RegisterConsumer(consumer);
+            MetricManager.RegisterListener(consumer);
             MetricManager.PollMetrics();
 
 


### PR DESCRIPTION
* make registration tracking explicit by turning weak references into a regular hash table.
* Add an unregister method to stop listening for events
* rename consumer to listener to be more in line with other OpenTAP APIs (result listener for example)

Closes #4     
Closes #3 