### PR TITLE
Rename ephemeral

### DIFF
--- a/OpenTap.Metrics/MetricAttribute.cs
+++ b/OpenTap.Metrics/MetricAttribute.cs
@@ -5,24 +5,24 @@ namespace OpenTap.Metrics;
 /// <summary> Defines a property as a metric. </summary>
 public class MetricAttribute : Attribute
 {
-    /// <summary> Optionally, the name of the metric. </summary>
+    /// <summary> The name of the metric. </summary>
     public string Name { get; }
 
     /// <summary> Optionally give the metric a group. </summary>
     public string Group { get; }
 
     /// <summary> Whether this metric can be polled or will be published out of band. </summary>
-    public bool Ephemeral { get; }
+    public MetricKind Kind { get; }
 
     /// <summary> Creates a new instance of the metric attribute </summary>
     ///  <param name="name">The name of the metric.</param>
     ///  <param name="group">The group of the metric.</param>
-    ///  <param name="ephemeral"> Whether the metric is ephemeral. </param>
-    public MetricAttribute(string name, string group = null, bool ephemeral = false)
+    ///  <param name="kind"> The push / poll semantics of the metric. </param>
+    public MetricAttribute(string name, string group = null, MetricKind kind = MetricKind.Poll)
     {
-        Ephemeral = ephemeral;
         Name = name;
         Group = group;
+        Kind = kind;
     }
 
     /// <summary> Creates a new instance of the metric attribute.</summary>

--- a/OpenTap.Metrics/MetricInfo.cs
+++ b/OpenTap.Metrics/MetricInfo.cs
@@ -8,9 +8,10 @@ namespace OpenTap.Metrics;
 public class MetricInfo
 {
     /// <summary> Whether this metric can be polled or will be published out of band. </summary>
-    public bool Ephemeral { get; }
-
     public MetricKind Kind { get; }
+
+    /// <summary> The type of this metric. </summary>
+    public MetricType Type { get; }
 
     /// <summary> The metric member object. </summary>
     IMemberData Member { get; }
@@ -36,19 +37,19 @@ public class MetricInfo
         GroupName = groupName;
         Attributes = Member.Attributes.ToArray();
         var metricAttr = Attributes.OfType<MetricAttribute>().FirstOrDefault();
-        if (metricAttr != null)
-            Ephemeral = metricAttr.Ephemeral;
+        Kind = metricAttr?.Kind ?? MetricKind.Poll;
+
         if (mem.TypeDescriptor.IsNumeric())
         {
-            Kind = MetricKind.Double;
+            Type = MetricType.Double;
         }
         else if (mem.TypeDescriptor.DescendsTo(typeof(string)))
         {
-            Kind = MetricKind.String;
+            Type = MetricType.String;
         }
         else if (mem.TypeDescriptor.DescendsTo(typeof(bool)))
         {
-            Kind = MetricKind.Boolean;
+            Type = MetricType.Boolean;
         }
 
         Name = metricAttr?.Name ?? Member.GetDisplayAttribute()?.Name;
@@ -58,14 +59,14 @@ public class MetricInfo
     /// <param name="name">The name of the metric.</param>
     /// <param name="groupName">The name of the metric group.</param>
     /// <param name="attributes">The attributes of the metric.</param>
-    ///  <param name="ephemeral"> Whether the metric is ephemeral. </param>
-    public MetricInfo(string name, string groupName, IEnumerable<object> attributes, bool ephemeral)
+    ///  <param name="kind">The push / poll semantics of the metric. </param>
+    public MetricInfo(string name, string groupName, IEnumerable<object> attributes, MetricKind kind)
     {
         Name = name;
         Member = null;
         GroupName = groupName;
         Attributes = attributes;
-        Ephemeral = ephemeral;
+        Kind = kind;
     }
 
     /// <summary>

--- a/OpenTap.Metrics/MetricKind.cs
+++ b/OpenTap.Metrics/MetricKind.cs
@@ -1,9 +1,14 @@
+using System;
+
 namespace OpenTap.Metrics;
 
+[Flags]
 public enum MetricKind
 {
-    Unknown,
-    Double,
-    Boolean,
-    String
+    /// <summary> This metric can be polled. </summary>
+    Poll = 1,
+    /// <summary> This metric can be pushed out of band. </summary>
+    Push = 2,
+    /// <summary> This metric can be polled and pushed out of band. </summary>
+    PushPoll = Push | Poll,
 }

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -127,7 +127,7 @@ public static class MetricManager
     /// <summary> Poll metrics. </summary>
     public static void PollMetrics()
     {
-        var allMetrics = GetMetricInfos().Where(metric => metric.metric.Ephemeral == false).ToArray();
+        var allMetrics = GetMetricInfos().Where(metric => metric.metric.Kind.HasFlag(MetricKind.Poll)).ToArray();
         Dictionary<IMetricListener, MetricInfo[]> interestLookup = new Dictionary<IMetricListener, MetricInfo[]>();
         HashSet<MetricInfo> InterestMetrics = new HashSet<MetricInfo>();
         foreach (var consumer in _consumers)

--- a/OpenTap.Metrics/MetricType.cs
+++ b/OpenTap.Metrics/MetricType.cs
@@ -1,0 +1,9 @@
+namespace OpenTap.Metrics;
+
+public enum MetricType
+{
+    Unknown,
+    Double,
+    Boolean,
+    String
+}


### PR DESCRIPTION
This renames the mysterious Ephemeral bool to push / poll, which should clear up confusion about the intended use. A poll metric will be polled, and a push metric can be pushed. This also leaves us the opportunity to create new types of metrics in the future, though I can't currently see what other semantics would make sense.

Closes #13 