### PR TITLE
Rename IMetricUpdateCallback to IOnPollMetricsCallback

### DIFF
--- a/OpenTap.Metrics/IMetricUpdateCallback.cs
+++ b/OpenTap.Metrics/IMetricUpdateCallback.cs
@@ -1,8 +1,0 @@
-namespace OpenTap.Metrics;
-
-/// <summary> Defines a class which can update metrics. </summary>
-public interface IMetricUpdateCallback
-{
-    /// <summary> Updates metrics. </summary>   
-    void UpdateMetrics();
-}

--- a/OpenTap.Metrics/IOnPollMetricsCallback.cs
+++ b/OpenTap.Metrics/IOnPollMetricsCallback.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace OpenTap.Metrics;
+
+/// <summary> Defines a class which can update metrics. </summary>
+public interface IOnPollMetricsCallback
+{
+    /// <summary> Called right before the metric manager reads PollMetric properties. </summary>   
+    ///  <param name="metrics">List of metrics from this class that are about to be polled.</param>
+    void OnPollMetrics(IEnumerable<MetricInfo> metrics);
+}


### PR DESCRIPTION
The current name implies that the metric producer should push its metrics. The intention is to give it a chance to update its metrics because they are about to be polled.

The interface was also updated to let the implementation know which members will be polled. This should facilitate the most common pattern which is to check if a value needs to be updated (e.g. make a measurement), and then updating it if needed.

Since the input is constructed as a linq expression, the computation of polled values should be quite cheap if the producer does not care.

Closes #12 