### PR TITLE
Renamed package from "Metrics" to "Metrics and Assets"

### DIFF
--- a/OpenTap.Metrics/package.xml
+++ b/OpenTap.Metrics/package.xml
@@ -19,7 +19,7 @@ $(GitVersion) - Gets the version from Git in the recommended format Major.Minor.
     <PackageDependency Package="OpenTAP" Version="^9.16.4+654f0b6b" />
   </Dependencies>
   <Files>
-    <File Path="Packages/Metrics/OpenTap.Metrics.dll" SourcePath="OpenTap.Metrics.dll">
+    <File Path="Packages/Metrics and Assets/OpenTap.Metrics.dll" SourcePath="OpenTap.Metrics.dll">
         <Sign Certificate="Keysight Technologies, Inc."/>
         <!-- This is being set automatically in the .csproj  -->
         <!-- <SetAssemblyInfo Attributes="Version"/> -->

--- a/OpenTap.Metrics/package.xml
+++ b/OpenTap.Metrics/package.xml
@@ -6,8 +6,12 @@ Version: The version of the package. Must be in a semver 2.0 compatible format. 
 For Version the following macro is available (Only works if the project directory is under Git source control):
 $(GitVersion) - Gets the version from Git in the recommended format Major.Minor.Build-PreRelease+CommitHash.BranchName.
 -->
-<Package Name="Metrics" xmlns="http://opentap.io/schemas/package" InfoLink="" Version="$(GitVersion)" OS="Windows,Linux,MacOS">
-  <Description>This plugin provides interfaces to publish, poll, and subscribe to metrics.</Description>
+<Package Name="Metrics and Assets" xmlns="http://opentap.io/schemas/package" InfoLink="" Version="$(GitVersion)" OS="Windows,Linux,MacOS">
+  <Description>
+    This package defines plugin interfaces to provide metrics and discover assets.
+    Metrics are values (bool,double,string) that can be used to monitor the status/health of the system. Centralized monitoring tools can use these metrics to provide a dashboard.
+    Assets include any resource that can be used by OpenTAP, such as instruments and and other devices used as part of a test. 
+    </Description>
   <Owner>OpenTAP</Owner>
   <SourceUrl>https://github.com/opentap/OpenTap.Metrics</SourceUrl>
   <SourceLicense>MPL-2.0</SourceLicense>

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# OpenTAP Metrics
+# Metrics and Assets
 
 This plugin provides interfaces to push, poll, and subscribe to metrics. This
 can be used to e.g. make periodic measurements on a connected instrument. By
@@ -6,6 +6,11 @@ formalizing the concept of push (event-based) and poll (measurement-based)
 metrics, and providing a common way to produce and consume them, this plugin
 enables a great deal of interoperability between different metric providers and
 listeners.
+
+This package also defines an Asset Discovery plugin type and
+related functionality. This is a semi independent feature, but it is related to
+metrics in that it metrics can be associated with an asset instead of the default
+of associating the metric with the entire system.
 
 ## Poll Metrics
 


### PR DESCRIPTION
After some discussion with @jfaaborg  and @alnlarsen, we decided on this approach instead of splitting Metrics and Assets into two packages to reduce the risk of diamond dependencies as most implementations would reference both packages. This way, we can ensure that the two packages are always in sync.
