### PR TITLE
Standalone Metrics and Assets PoC

### DIFF
--- a/OpenTap.Metrics.Nats/AssetDiscoveryEndpoint.cs
+++ b/OpenTap.Metrics.Nats/AssetDiscoveryEndpoint.cs
@@ -12,13 +12,7 @@ namespace OpenTap.Metrics.Nats
         private readonly TraceSource _log = Log.CreateSource("Asset Discovery");
         public AssetDiscoveryEndpoint()
         {
-            var runnerConnection = RunnerExtension.GetConnection();
-            // OpenTap.Runner.<RunnerId>.Request.AssetDiscovery
-            runnerConnection.Connection.SubscribeAsync($"{runnerConnection.BaseSubject}.Request.AssetDiscovery", (sender, args) =>
-            {
-                var response = DiscoverAllAssets();
-                runnerConnection.Connection.Publish(args.Message.Reply, Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response)));
-            });
+            RunnerExtension.MapEndpoint("DiscoverAssets", DiscoverAllAssets);
         }
 
         private AssetDiscoveryResponse DiscoverAllAssets()

--- a/OpenTap.Metrics.Nats/AssetDiscoveryEndpoint.cs
+++ b/OpenTap.Metrics.Nats/AssetDiscoveryEndpoint.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using OpenTap.Metrics.AssetDiscovery;
+
+namespace OpenTap.Metrics.Nats
+{
+    public class AssetDiscoveryEndpoint
+    {
+        private readonly TraceSource _log = Log.CreateSource("Asset Discovery");
+        public AssetDiscoveryEndpoint()
+        {
+            var runnerConnection = RunnerExtension.GetConnection();
+            // OpenTap.Runner.<RunnerId>.Request.AssetDiscovery
+            runnerConnection.Connection.SubscribeAsync($"{runnerConnection.BaseSubject}.Request.AssetDiscovery", (sender, args) =>
+            {
+                var response = DiscoverAllAssets();
+                runnerConnection.Connection.Publish(args.Message.Reply, Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response)));
+            });
+        }
+
+        private AssetDiscoveryResponse DiscoverAllAssets()
+        {
+            AssetDiscoveryResponse discoveryResponse = new AssetDiscoveryResponse
+            {
+                AssetProviders = AssetDiscoveryManager.DiscoverAllAssets().Select(kvp => new AssetDiscoveryResult
+                {
+                    Name = kvp.Key.GetType().Name,
+                    Priority = kvp.Key.Priority,
+                    IsSuccess = kvp.Value.IsSuccess,
+                    Error = kvp.Value.Error,
+                    DiscoveredAssets = kvp.Value.Assets?.ToList() ?? Enumerable.Empty<DiscoveredAsset>().ToList()
+                }).ToList(),
+                LastSeen = DateTime.UtcNow,
+            };
+
+            _log.Debug($"Asset Discovery: {string.Join(", ", discoveryResponse.AssetProviders.Select(s => $"{s.Name} ({s.DiscoveredAssets.Count} assets)"))}");
+            return discoveryResponse;
+        }
+    }
+
+    public class AssetDiscoveryResponse
+    {
+        public List<AssetDiscoveryResult> AssetProviders { get; set; }
+
+        public DateTime LastSeen { get; set; }
+    }
+
+    public class AssetDiscoveryResult
+    {
+        public List<DiscoveredAsset> DiscoveredAssets { get; set; }
+        public double Priority { get; set; }
+        public string Name { get; set; }
+        public bool IsSuccess { get; set; }
+        public string Error { get; set; }
+    }
+}

--- a/OpenTap.Metrics.Nats/EnableMetricsPollingEndpoint.cs
+++ b/OpenTap.Metrics.Nats/EnableMetricsPollingEndpoint.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Newtonsoft.Json;
+using OpenTap.Metrics.AssetDiscovery;
+
+namespace OpenTap.Metrics.Nats
+{
+    public class EnableMetricsPollingEndpoint
+    {
+        private readonly TraceSource _log = Log.CreateSource("Metrics Endpoint");
+        public EnableMetricsPollingEndpoint()
+        {
+            RunnerExtension.MapEndpoint<EnableMetricsPollingRequest, EnableMetricsPollingResponse>("SetupMetricsPolling", SetupMetricsPolling);
+        }
+
+        private EnableMetricsPollingResponse SetupMetricsPolling(EnableMetricsPollingRequest request)
+        {
+            if (request.Enabled)
+            {
+                NatsMetricPusher.Start();
+            }
+            else
+            {
+                NatsMetricPusher.Stop();
+            }
+
+            return new EnableMetricsPollingResponse
+            {
+                JetStreamName = NatsMetricPusher.MetricsStreamName,
+                Enabled = request.Enabled
+            };
+        }
+    }
+
+    public class EnableMetricsPollingResponse
+    {
+        public string JetStreamName { get; set; }
+        public bool Enabled { get; set; }
+    }
+
+    public class EnableMetricsPollingRequest
+    {
+        public bool Enabled { get; set; }
+    }
+}

--- a/OpenTap.Metrics.Nats/MetricDto.cs
+++ b/OpenTap.Metrics.Nats/MetricDto.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace OpenTap.Metrics.Nats
+{
+    internal class MetricDto
+    {
+        public string Name { get; set; }
+        public object Value { get; set; }
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}
+

--- a/OpenTap.Metrics.Nats/NatsMetricPusher.cs
+++ b/OpenTap.Metrics.Nats/NatsMetricPusher.cs
@@ -11,11 +11,11 @@ using OpenTap.Runner.Client;
 
 namespace OpenTap.Metrics.Nats
 {
-    public class NatsMetricPusher : IMetricsSink
+    public class NatsMetricPusher
     {
         private TraceSource log = Log.CreateSource("NatsMetricPusher");
         private readonly string MetricsStreamName = "Metric";
-        private RunnerExtension runnerConnection;
+        //private RunnerExtension runnerConnection;
         private IJetStream _jetStream;
 
 
@@ -41,7 +41,7 @@ namespace OpenTap.Metrics.Nats
             int seconds = 0;
             while (!TapThread.Current.AbortToken.IsCancellationRequested)
             {
-                if (MetricsSettings.Current.Enabled)
+                if (MetricsSettings.Current.Any())
                 {
                     var pollMetrics = MetricsSettings.Current.Where(s => s.Metric.DefaultPollRate % seconds == 0).Select(p => p.Metric).ToList();
                     if (pollMetrics.Any())

--- a/OpenTap.Metrics.Nats/NatsMetricPusher.cs
+++ b/OpenTap.Metrics.Nats/NatsMetricPusher.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Timers;
 using NATS.Client.Internals;
 using NATS.Client.JetStream;
 using Newtonsoft.Json;
@@ -13,55 +15,81 @@ namespace OpenTap.Metrics.Nats
 {
     public class NatsMetricPusher
     {
-        private TraceSource log = Log.CreateSource("NatsMetricPusher");
-        private readonly string MetricsStreamName = "Metric";
+        internal const string MetricsStreamName = "Metric";
+
+        private static readonly TraceSource log = Log.CreateSource("Metrics");
+        private static readonly NatsMetricPusher instance = new NatsMetricPusher();
+
         private RunnerExtension runnerConnection;
         private IJetStream _jetStream;
+        private Timer timer;
 
-        public NatsMetricPusher()
+        public static void Start()
         {
-            TapThread.Start(() =>
+            try
             {
-                try
+                instance.SetupMetricsStream();
+                instance.timer = new Timer()
                 {
-                    SetupMetricsStream();
-                    StartMetricsPollThread();
-                }
-                catch (Exception e)
-                {
-                    log.Error("Error setting up metrics stream");
-                    log.Debug(e);
-                }
-            });
+                    Interval = 1000,
+                    AutoReset = true
+                };
+                instance.timer.Elapsed += instance.PollMetrics;
+                instance.timer.Start();
+                log.Info("Metrics polling started.");
+            }
+            catch (Exception e)
+            {
+                log.Error("Error setting up metrics stream");
+                log.Debug(e);
+            }
         }
 
-        private void StartMetricsPollThread()
+        public static void Stop()
         {
-            int seconds = 0;
-            while (!TapThread.Current.AbortToken.IsCancellationRequested)
+            instance.timer.Stop();
+            log.Info("Metrics polling stopped.");
+        }
+
+        private void PollMetrics(object sender, ElapsedEventArgs e)
+        {
+            try
             {
                 if (MetricsSettings.Current.Any())
                 {
-                    var pollMetrics = MetricsSettings.Current.Where(s => s.Metric.DefaultPollRate % seconds == 0).Select(p => p.Metric).ToList();
+                    long seconds = (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
+                    var pollMetrics = MetricsSettings.Current.Where(s => seconds % s.Metric.DefaultPollRate == 0).Select(p => p.Metric).ToList();
                     if (pollMetrics.Any())
                     {
+                        log.Debug($"Polling {pollMetrics.Count} metrics");
                         var polledMetrics = MetricManager.PollMetrics(pollMetrics);
                         foreach (var metric in polledMetrics)
                         {
                             StoreMetricOnJetStream(metric);
                         }
                     }
-
-                    seconds++;
-                    TapThread.Sleep(1000);
+                    else
+                    {
+                        log.Debug("No metrics needs to be polled");
+                    }
                 }
+                else
+                {
+                    log.Debug("No metrics to enabled");
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Error("Error polling metrics");
+                log.Debug(ex);
             }
         }
 
         private void StoreMetricOnJetStream(IMetric metric)
         {
-            var cleanFullName = Regex.Replace(metric.Info.MetricFullName, @"[> \.\*]", "_");
-            string subject = $"{runnerConnection.BaseSubject}.Metrics.{cleanFullName}";
+            var name = escapeSubject(metric.Info.Name);
+            var group = escapeSubject(metric.Info.GroupName);
+            string subject = $"{runnerConnection.BaseSubject}.Metrics.{group}.{name}";
             MetricDto dto = new MetricDto()
             {
                 Name = metric.Info.MetricFullName,
@@ -75,6 +103,16 @@ namespace OpenTap.Metrics.Nats
                 log.Warning("Connection is closed, not publishing metrics");
         }
 
+        private string escapeSubject(string subject)
+        {
+            // https://docs.nats.io/nats-concepts/subjects#characters-allowed-and-recommended-for-subject-names
+            return subject
+                .Replace(" ", "_")
+                .Replace(">", "-")
+                .Replace("*", "-")
+                .Replace(".", "-");
+        }
+
         private void SetupMetricsStream()
         {
             runnerConnection = RunnerExtension.GetConnection();
@@ -86,6 +124,7 @@ namespace OpenTap.Metrics.Nats
                 .WithDiscardPolicy(DiscardPolicy.Old)
                 .WithSubjects($"{runnerConnection.BaseSubject}.Metrics.>")
                 .WithRetentionPolicy(RetentionPolicy.Limits)
+                .WithSubjectTransform(new SubjectTransform($"{runnerConnection.BaseSubject}.Metrics.>", "Metric.>"))
                 .WithAllowDirect(true)
                 .WithMaxAge(Duration.OfDays(2))
                 .Build();
@@ -93,6 +132,29 @@ namespace OpenTap.Metrics.Nats
             StreamInfo streamInfo = streamNames.Contains(metricsStream.Name) ? jsManagementContext.UpdateStream(metricsStream) : jsManagementContext.AddStream(metricsStream);
             log.Info($"Storage '{metricsStream.Name}' is configured. Currently has {streamInfo.State.Messages} messages");
             _jetStream = runnerConnection.Connection.CreateJetStreamContext();
+        }
+    }
+
+    public class NatsMetrics : IMetricSource
+    {
+        private readonly RunnerExtension runnerConnection;
+
+        [MetaData]
+        public string ServerVersion => "2.10.20";
+        [Metric("Roundtrip time", "Runner", DefaultPollRate = 5, DefaultEnabled = true)]
+        public double RoundtripTime => getRoundtripTime();
+
+        public NatsMetrics()
+        {
+            runnerConnection = RunnerExtension.GetConnection();
+        }
+
+        private double getRoundtripTime()
+        {
+            // Stopwatch stopwatch = Stopwatch.StartNew();
+            // runnerConnection.Connection.Request("OpenTap.RunnerRegistry.Request.Ping", null, 1000);
+            // return stopwatch.ElapsedMilliseconds;
+            return 0.1;
         }
     }
 }

--- a/OpenTap.Metrics.Nats/NatsMetricPusher.cs
+++ b/OpenTap.Metrics.Nats/NatsMetricPusher.cs
@@ -15,9 +15,8 @@ namespace OpenTap.Metrics.Nats
     {
         private TraceSource log = Log.CreateSource("NatsMetricPusher");
         private readonly string MetricsStreamName = "Metric";
-        //private RunnerExtension runnerConnection;
+        private RunnerExtension runnerConnection;
         private IJetStream _jetStream;
-
 
         public NatsMetricPusher()
         {
@@ -95,12 +94,5 @@ namespace OpenTap.Metrics.Nats
             log.Info($"Storage '{metricsStream.Name}' is configured. Currently has {streamInfo.State.Messages} messages");
             _jetStream = runnerConnection.Connection.CreateJetStreamContext();
         }
-    }
-
-    internal class MetricDto
-    {
-        public string Name { get; set; }
-        public object Value { get; set; }
-        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/OpenTap.Metrics.Nats/NatsMetricPusher.cs
+++ b/OpenTap.Metrics.Nats/NatsMetricPusher.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NATS.Client.Internals;
+using NATS.Client.JetStream;
+using Newtonsoft.Json;
+using OpenTap.Metrics.Settings;
+using OpenTap.Runner.Client;
+
+namespace OpenTap.Metrics.Nats
+{
+    public class NatsMetricPusher : IMetricsSink
+    {
+        private TraceSource log = Log.CreateSource("NatsMetricPusher");
+        private readonly string MetricsStreamName = "Metric";
+        private RunnerExtension runnerConnection;
+        private IJetStream _jetStream;
+
+
+        public NatsMetricPusher()
+        {
+            TapThread.Start(() =>
+            {
+                try
+                {
+                    SetupMetricsStream();
+                    StartMetricsPollThread();
+                }
+                catch (Exception e)
+                {
+                    log.Error("Error setting up metrics stream");
+                    log.Debug(e);
+                }
+            });
+        }
+
+        private void StartMetricsPollThread()
+        {
+            int seconds = 0;
+            while (!TapThread.Current.AbortToken.IsCancellationRequested)
+            {
+                if (MetricsSettings.Current.Enabled)
+                {
+                    var pollMetrics = MetricsSettings.Current.Where(s => s.Metric.DefaultPollRate % seconds == 0).Select(p => p.Metric).ToList();
+                    if (pollMetrics.Any())
+                    {
+                        var polledMetrics = MetricManager.PollMetrics(pollMetrics);
+                        foreach (var metric in polledMetrics)
+                        {
+                            StoreMetricOnJetStream(metric);
+                        }
+                    }
+
+                    seconds++;
+                    TapThread.Sleep(1000);
+                }
+            }
+        }
+
+        private void StoreMetricOnJetStream(IMetric metric)
+        {
+            var cleanFullName = Regex.Replace(metric.Info.MetricFullName, @"[> \.\*]", "_");
+            string subject = $"{runnerConnection.BaseSubject}.Metrics.{cleanFullName}";
+            MetricDto dto = new MetricDto()
+            {
+                Name = metric.Info.MetricFullName,
+                Value = metric.Value,
+                Metadata = metric.MetaData
+            };
+
+            if (!runnerConnection.Connection.IsClosed())
+                _jetStream.Publish(subject, Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(dto)));
+            else
+                log.Warning("Connection is closed, not publishing metrics");
+        }
+
+        private void SetupMetricsStream()
+        {
+            runnerConnection = RunnerExtension.GetConnection();
+
+            var jsManagementContext = runnerConnection.Connection.CreateJetStreamManagementContext();
+            StreamConfiguration metricsStream = StreamConfiguration.Builder()
+                .WithName(MetricsStreamName)
+                .WithStorageType(StorageType.File)
+                .WithDiscardPolicy(DiscardPolicy.Old)
+                .WithSubjects($"{runnerConnection.BaseSubject}.Metrics.>")
+                .WithRetentionPolicy(RetentionPolicy.Limits)
+                .WithAllowDirect(true)
+                .WithMaxAge(Duration.OfDays(2))
+                .Build();
+            IList<string> streamNames = jsManagementContext.GetStreamNames();
+            StreamInfo streamInfo = streamNames.Contains(metricsStream.Name) ? jsManagementContext.UpdateStream(metricsStream) : jsManagementContext.AddStream(metricsStream);
+            log.Info($"Storage '{metricsStream.Name}' is configured. Currently has {streamInfo.State.Messages} messages");
+            _jetStream = runnerConnection.Connection.CreateJetStreamContext();
+        }
+    }
+
+    internal class MetricDto
+    {
+        public string Name { get; set; }
+        public object Value { get; set; }
+        public Dictionary<string, string> Metadata { get; set; }
+    }
+}

--- a/OpenTap.Metrics.Nats/OpenTap.Metrics.Nats.csproj
+++ b/OpenTap.Metrics.Nats/OpenTap.Metrics.Nats.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        <DEBUG_OPENTAP_NATS>true</DEBUG_OPENTAP_NATS>
+        <DEBUG_OPENTAP_NATS>false</DEBUG_OPENTAP_NATS>
         <OutputPath>../bin/$(Configuration)</OutputPath>
     </PropertyGroup>
 
@@ -16,14 +16,12 @@
         <Reference Include="OpenTap.Runner.Client">
             <HintPath>..\..\runner-client-dotnet\OpenTap.Runner.Client.CSharp\bin\Debug\OpenTap.Runner.Client.dll</HintPath>
         </Reference>
+        <Reference Include="Newtonsoft.Json">
+            <HintPath>..\..\runner-client-dotnet\OpenTap.Runner.Client.CSharp\bin\Debug\Newtonsoft.Json.dll</HintPath>
+        </Reference>
     </ItemGroup>
     <ItemGroup Condition="'$(DEBUG_OPENTAP_NATS)' == 'false'">
         <PackageReference Include="OpenTAP.Runner.Client" Version="2.6.0-beta.3"/>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     </ItemGroup>
-    <ItemGroup>
-      <Reference Include="Newtonsoft.Json">
-        <HintPath>..\..\runner-client-dotnet\OpenTap.Runner.Client.CSharp\bin\Debug\Newtonsoft.Json.dll</HintPath>
-      </Reference>
-    </ItemGroup>
-
 </Project>

--- a/OpenTap.Metrics.Nats/OpenTap.Metrics.Nats.csproj
+++ b/OpenTap.Metrics.Nats/OpenTap.Metrics.Nats.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <DEBUG_OPENTAP_NATS>true</DEBUG_OPENTAP_NATS>
+        <OutputPath>../bin/$(Configuration)</OutputPath>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\OpenTap.Metrics\OpenTap.Metrics.csproj"/>
+        <PackageReference Include="NATS.Client" Version="1.1.6"/>
+    </ItemGroup>
+
+
+    <ItemGroup Condition="'$(DEBUG_OPENTAP_NATS)' == 'true'">
+        <Reference Include="OpenTap.Runner.Client">
+            <HintPath>..\..\runner-client-dotnet\OpenTap.Runner.Client.CSharp\bin\Debug\OpenTap.Runner.Client.dll</HintPath>
+        </Reference>
+    </ItemGroup>
+    <ItemGroup Condition="'$(DEBUG_OPENTAP_NATS)' == 'false'">
+        <PackageReference Include="OpenTAP.Runner.Client" Version="2.6.0-beta.3"/>
+    </ItemGroup>
+    <ItemGroup>
+      <Reference Include="Newtonsoft.Json">
+        <HintPath>..\..\runner-client-dotnet\OpenTap.Runner.Client.CSharp\bin\Debug\Newtonsoft.Json.dll</HintPath>
+      </Reference>
+    </ItemGroup>
+
+</Project>

--- a/OpenTap.Metrics.Nats/RunnerExtension.cs
+++ b/OpenTap.Metrics.Nats/RunnerExtension.cs
@@ -1,0 +1,26 @@
+using NATS.Client;
+
+namespace OpenTap.Metrics.Nats
+{
+    public class RunnerExtension
+    {
+        public IConnection Connection { get; }
+        public string RunnerId { get; }
+
+        private RunnerExtension(IConnection connection, string runnerId)
+        {
+            Connection = connection; RunnerId = runnerId; BaseSubject = $"OpenTap.Runner.{runnerId}";
+        }
+
+        public string BaseSubject { get; }
+        public static string DefaultServer = "nats://127.0.0.1:20111";
+
+        public static RunnerExtension GetConnection()
+        {
+            var options = ConnectionFactory.GetDefaultOptions();
+            options.Servers = new string[] { DefaultServer };
+            IConnection connection = new ConnectionFactory().CreateConnection(options);
+            return new RunnerExtension(connection, connection.ServerInfo.ServerName);
+        }
+    }
+}

--- a/OpenTap.Metrics.Nats/RunnerExtension.cs
+++ b/OpenTap.Metrics.Nats/RunnerExtension.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Text;
 using NATS.Client;
+using Newtonsoft.Json;
 
 namespace OpenTap.Metrics.Nats
 {
@@ -7,9 +10,24 @@ namespace OpenTap.Metrics.Nats
         public IConnection Connection { get; }
         public string RunnerId { get; }
 
+        private static RunnerExtension instance;
+        internal static RunnerExtension Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = GetConnection();
+                }
+                return instance;
+            }
+        }
+
         private RunnerExtension(IConnection connection, string runnerId)
         {
-            Connection = connection; RunnerId = runnerId; BaseSubject = $"OpenTap.Runner.{runnerId}";
+            Connection = connection;
+            RunnerId = runnerId;
+            BaseSubject = $"OpenTap.Runner.{runnerId}.Session.{GetSessionId()}";
         }
 
         public string BaseSubject { get; }
@@ -21,6 +39,40 @@ namespace OpenTap.Metrics.Nats
             options.Servers = new string[] { DefaultServer };
             IConnection connection = new ConnectionFactory().CreateConnection(options);
             return new RunnerExtension(connection, connection.ServerInfo.ServerName);
+        }
+
+        public static Guid GetSessionId()
+        {
+            var sessionIdVar = Environment.GetEnvironmentVariable("OPENTAP_RUNNER_SESSION_ID");
+            if (sessionIdVar == null)
+            {
+                throw new Exception("OPENTAP_RUNNER_SESSION_ID environment variable not set");
+            }
+            return Guid.Parse(sessionIdVar);
+        }
+
+        /// <summary>
+        /// Used by plugins to add endpoints to the runner API
+        /// </summary>
+        public static void MapEndpoint<Tresponse>(string endpoint, Func<Tresponse> handler)
+        {
+            Instance.Connection.SubscribeAsync($"{Instance.BaseSubject}.Request.{endpoint}", (sender, args) =>
+            {
+                var response = handler();
+                Instance.Connection.Publish(args.Message.Reply, Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response)));
+            });
+        }
+
+        /// <summary>
+        /// Used by plugins to add endpoints to the runner API
+        /// </summary>
+        public static void MapEndpoint<Trequest, Tresponse>(string endpoint, Func<Trequest, Tresponse> handler)
+        {
+            Instance.Connection.SubscribeAsync($"{Instance.BaseSubject}.Request.{endpoint}", (sender, args) =>
+            {
+                var response = handler(JsonConvert.DeserializeObject<Trequest>(Encoding.UTF8.GetString(args.Message.Data)));
+                Instance.Connection.Publish(args.Message.Reply, Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(response)));
+            });
         }
     }
 }

--- a/OpenTap.Metrics.Nats/Startup.cs
+++ b/OpenTap.Metrics.Nats/Startup.cs
@@ -1,0 +1,11 @@
+namespace OpenTap.Metrics.Nats
+{
+
+    public class MetricsPollingStartup : IStartupInfo
+    {
+        public void LogStartupInfo()
+        {
+            new NatsMetricPusher();
+        }
+    }
+}

--- a/OpenTap.Metrics.Nats/Startup.cs
+++ b/OpenTap.Metrics.Nats/Startup.cs
@@ -6,6 +6,7 @@ namespace OpenTap.Metrics.Nats
         public void LogStartupInfo()
         {
             new NatsMetricPusher();
+            new AssetDiscoveryEndpoint();
         }
     }
 }

--- a/OpenTap.Metrics.Nats/Startup.cs
+++ b/OpenTap.Metrics.Nats/Startup.cs
@@ -8,7 +8,7 @@ namespace OpenTap.Metrics.Nats
         {
             var log = Log.CreateSource("Metrics");
             {
-                log.Info("Setup metrics endpoints");
+                log.Debug("Setup metrics endpoints");
                 try
                 {
                     new AssetDiscoveryEndpoint();

--- a/OpenTap.Metrics.Nats/Startup.cs
+++ b/OpenTap.Metrics.Nats/Startup.cs
@@ -1,12 +1,27 @@
+using System;
+
 namespace OpenTap.Metrics.Nats
 {
-
     public class MetricsPollingStartup : IStartupInfo
     {
         public void LogStartupInfo()
         {
-            new NatsMetricPusher();
-            new AssetDiscoveryEndpoint();
+            var log = Log.CreateSource("Metrics");
+            {
+                log.Info("Setup metrics endpoints");
+                try
+                {
+                    new AssetDiscoveryEndpoint();
+                    new EnableMetricsPollingEndpoint();
+                }
+                catch (Exception e)
+                {
+                    // This happens e.g. in the Runner process itself when there is no leafnode yet.
+                    log.Error("Error setting up metrics endpoints");
+                    log.Debug(e);
+                }
+            }
         }
+
     }
 }

--- a/OpenTap.Metrics.sln
+++ b/OpenTap.Metrics.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTap.Metrics", "OpenTap.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTap.Metrics.UnitTest", "OpenTap.Metrics.UnitTest\OpenTap.Metrics.UnitTest.csproj", "{A15E3E1A-961D-4103-9547-62A8F06993EA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTap.Metrics.Nats", "OpenTap.Metrics.Nats\OpenTap.Metrics.Nats.csproj", "{1FE4AE27-797F-4189-BE49-B3A496EA23C5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{A15E3E1A-961D-4103-9547-62A8F06993EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A15E3E1A-961D-4103-9547-62A8F06993EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A15E3E1A-961D-4103-9547-62A8F06993EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1FE4AE27-797F-4189-BE49-B3A496EA23C5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1FE4AE27-797F-4189-BE49-B3A496EA23C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1FE4AE27-797F-4189-BE49-B3A496EA23C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1FE4AE27-797F-4189-BE49-B3A496EA23C5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/OpenTap.Metrics/IMetricsSink.cs
+++ b/OpenTap.Metrics/IMetricsSink.cs
@@ -1,0 +1,6 @@
+namespace OpenTap.Metrics;
+
+public interface IMetricsSink : ITapPlugin
+{
+    
+}

--- a/OpenTap.Metrics/IMetricsSink.cs
+++ b/OpenTap.Metrics/IMetricsSink.cs
@@ -1,6 +1,0 @@
-namespace OpenTap.Metrics;
-
-public interface IMetricsSink : ITapPlugin
-{
-    
-}

--- a/OpenTap.Metrics/OpenTap.Metrics.csproj
+++ b/OpenTap.Metrics/OpenTap.Metrics.csproj
@@ -5,8 +5,6 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <TargetFrameworkIdentifier></TargetFrameworkIdentifier>
-    <TargetFrameworkVersion></TargetFrameworkVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>12</LangVersion>
   </PropertyGroup>
@@ -35,7 +33,12 @@
   <ItemGroup>
     <InternalsVisibleTo Include="OpenTap.Metrics.UnitTest" />
   </ItemGroup>
-  
+
+
+  <ItemGroup Condition="$(OS) == 'UNIX' AND '$(Configuration)' == 'Debug'">
+    <OpenTapPackageReference Include="TUI" version="1"/>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />
   </ItemGroup>

--- a/OpenTap.Metrics/Properties/launchSettings.json
+++ b/OpenTap.Metrics/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "Debug with editor (Windows)": {
+      "commandName": "Executable",
+      "commandLineArgs": "tui",
+      "executablePath": "tap.exe",
+      "dotnetRunMessages": true
+    },
+    "Debug with editor (Linux / Mac)": {
+      "commandName": "Executable",
+      "commandLineArgs": "tui",
+      "executablePath": "tap",
+      "dotnetRunMessages": true
+    }
+  }
+}

--- a/OpenTap.Metrics/Settings/MetricsSettings.cs
+++ b/OpenTap.Metrics/Settings/MetricsSettings.cs
@@ -178,20 +178,4 @@ public class MetricsSettingsItem : IMetricsSettingsItem
 [Display("Metrics", "List of enabled metrics that should be monitored.")]
 public class MetricsSettings : ComponentSettingsList<MetricsSettings, IMetricsSettingsItem>
 {
-    private List<IMetricsSink> _sinks = new List<IMetricsSink>();
-
-    public MetricsSettings()
-    {
-        var metricSinks = TypeData.GetDerivedTypes<IMetricsSink>();
-        foreach (var metricSink in metricSinks)
-        {
-            if (metricSink.CanCreateInstance)
-            {
-                var sink = (IMetricsSink)metricSink.CreateInstance();
-                _sinks.Add(sink);
-            }
-        }
-    }
-
-    [Browsable(false)] public bool Enabled { get; set; } = true;
 }

--- a/OpenTap.Metrics/Settings/MetricsSettings.cs
+++ b/OpenTap.Metrics/Settings/MetricsSettings.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Xml.Serialization;
@@ -45,7 +46,7 @@ public class MetricsSettingsItem : IMetricsSettingsItem
 
     /// <summary> Whether this metric can be polled or will be published out of band. </summary>
     [Display("Kind", "The kind of this metric.", Order: 4), Browsable(true)]
-    public MetricKind Kind => Metric.Kind; 
+    public MetricKind Kind => Metric.Kind;
 
     [Browsable(false)]
     public int[] SuggestedPollRates => new int[] { 5, 10, 30, 60, 300, 900, 1800, 3600, 7200, 86400 }
@@ -75,7 +76,9 @@ public class MetricsSettingsItem : IMetricsSettingsItem
         var plural = v != 1;
         return plural ? $"Every {v} {unit}s" : $"Every {unit}";
     }
+
     [Browsable(false)] public bool CanPoll => Metric?.Kind.HasFlag(MetricKind.Poll) ?? false;
+
     string[] getSuggestedPollRateStrings()
     {
         if (!CanPoll)
@@ -95,8 +98,7 @@ public class MetricsSettingsItem : IMetricsSettingsItem
 
     [Browsable(false)] public int PollRate => SuggestedPollRates[AvailablePollRateStrings.IndexOf(PollRateString)];
 
-    [Browsable(false)]
-    public string[] AvailablePollRateStrings { get; set; }
+    [Browsable(false)] public string[] AvailablePollRateStrings { get; set; }
 
     private string _pollRateString;
 
@@ -149,10 +151,11 @@ public class MetricsSettingsItem : IMetricsSettingsItem
             }
         }
 
-        return null; 
+        return null;
     }
 
     private MetricInfo _metric;
+
     [Browsable(false)]
     [XmlIgnore]
     public MetricInfo Metric
@@ -175,5 +178,20 @@ public class MetricsSettingsItem : IMetricsSettingsItem
 [Display("Metrics", "List of enabled metrics that should be monitored.")]
 public class MetricsSettings : ComponentSettingsList<MetricsSettings, IMetricsSettingsItem>
 {
-    
+    private List<IMetricsSink> _sinks = new List<IMetricsSink>();
+
+    public MetricsSettings()
+    {
+        var metricSinks = TypeData.GetDerivedTypes<IMetricsSink>();
+        foreach (var metricSink in metricSinks)
+        {
+            if (metricSink.CanCreateInstance)
+            {
+                var sink = (IMetricsSink)metricSink.CreateInstance();
+                _sinks.Add(sink);
+            }
+        }
+    }
+
+    [Browsable(false)] public bool Enabled { get; set; } = true;
 }


### PR DESCRIPTION
OpenTap.Metrics.Nats to try connect to local runner, create 'Metric' JetStream and start polling metrics and putting them in the stream.

Very rough PoC.

- Publishes to 'OpenTap.Runner.<RunnerId>.Metrics.<MetricsFullName>'
- Needs better polling threading
- IMetricsSink implemented in order to poke OpenTap.Metrics.Nats to start - maybe another approach is better? 