### PR TITLE
Add support for metric plugin source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
 
   publish:
-    if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')
+    # if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')
     runs-on:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
 
   publish:
-    # if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release') || contains(github.ref, 'refs/tags/v')
     runs-on:
        group: OpenTAP-SpokeVPC
        labels:  [Linux, X64]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
             "args": [
                 "build",
                 "-c",
-                "debug",
+                "Debug",
                 "${workspaceFolder}"
             ],
             "problemMatcher": "$msCompile",
@@ -23,6 +23,8 @@
             "type": "process",
             "args": [
                 "build",
+                "-c",
+                "Release",
                 "${workspaceFolder}"
             ],
             "problemMatcher": "$msCompile",

--- a/OpenTap.Metrics.Nats/NatsMetricPusher.cs
+++ b/OpenTap.Metrics.Nats/NatsMetricPusher.cs
@@ -138,7 +138,7 @@ namespace OpenTap.Metrics.Nats
     public class NatsMetrics : IMetricSource, IOnPollMetricsCallback
     {
         private static readonly TraceSource log = Log.CreateSource("Metrics");
-        private readonly RunnerExtension runnerConnection;
+        private RunnerExtension _runnerConnection;
 
         [MetaData]
         public string StreamName => NatsMetricPusher.MetricsStreamName;
@@ -147,9 +147,16 @@ namespace OpenTap.Metrics.Nats
         [Metric("Storage Age [h]", "Metrics", DefaultPollRate = 15, DefaultEnabled = false)]
         public int MetricsStreamAge { get; set; }
 
-        public NatsMetrics()
+        private RunnerExtension runnerConnection
         {
-            runnerConnection = RunnerExtension.GetConnection();
+            get
+            {
+                if (_runnerConnection == null)
+                {
+                    _runnerConnection = RunnerExtension.GetConnection();
+                }
+                return _runnerConnection;
+            }
         }
 
         public void OnPollMetrics(IEnumerable<MetricInfo> metrics)

--- a/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
+++ b/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
@@ -78,7 +78,7 @@ public class DynamicMetricTests
         public object LastMetric { get; private set; }
         public void OnPushMetric(IMetric table)
         {
-            if (table.Info.MetricFullName is "Dynamic Metric Test / Pusher" or "Dynamic Nullable Metric Test / Pusher")
+            if (table.Info.MetricFullName is "Dynamic Metric Test \\ Pusher" or "Dynamic Nullable Metric Test \\ Pusher")
                 LastMetric = table.Value;
         }
     }

--- a/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
+++ b/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
@@ -168,19 +168,19 @@ public class MetricManagerTest
         InstrumentSettings.Current.Add(instrTest);
         var metrics = MetricManager.GetMetricInfos().ToArray();
 
-        var testMetric = metrics.FirstOrDefault(m => m.MetricFullName == "INST / Test");
+        var testMetric = metrics.FirstOrDefault(m => m.MetricFullName == "INST \\ Test");
         Assert.IsNotNull(testMetric);
         var range = testMetric.Attributes.OfType<RangeAttribute>().FirstOrDefault();
         Assert.IsNotNull(range);
         Assert.IsTrue(range.Minimum == 0.0);
 
-        Assert.IsTrue(metrics.Any(m => m.MetricFullName == "INST / v"));
+        Assert.IsTrue(metrics.Any(m => m.MetricFullName == "INST \\ v"));
 
-        Assert.Contains("Test Metric Producer / Y", metrics.Select(m => m.MetricFullName).ToArray());
+        Assert.Contains("Test Metric Producer \\ Y", metrics.Select(m => m.MetricFullName).ToArray());
         InstrumentSettings.Current.Remove(instrTest);
         metrics = MetricManager.GetMetricInfos().ToArray();
 
-        Assert.IsFalse(metrics.Any(m => m.MetricFullName == "INST / v"));
+        Assert.IsFalse(metrics.Any(m => m.MetricFullName == "INST \\ v"));
     }
 
     [Test]
@@ -190,13 +190,13 @@ public class MetricManagerTest
         var metricInfos = MetricManager.GetMetricInfos().Where(m => m.Source is FullMetricSource).ToArray();
 
         Assert.That(metricInfos, Has.Length.EqualTo(7));
-        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer / DoubleMetric"));
-        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer / DoubleMetricNull"));
-        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer / BoolMetric"));
-        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer / BoolMetricNull"));
-        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer / IntMetric"));
-        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer / IntMetricNull"));
-        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer / StringMetric"));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer \\ DoubleMetric"));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer \\ DoubleMetricNull"));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer \\ BoolMetric"));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer \\ BoolMetricNull"));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer \\ IntMetric"));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer \\ IntMetricNull"));
+        Assert.That(metricInfos, Has.One.Matches<MetricInfo>(m => m.MetricFullName == "Full Test Metric Producer \\ StringMetric"));
     }
 
     [Test]

--- a/OpenTap.Metrics.sln
+++ b/OpenTap.Metrics.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTap.Metrics.UnitTest", "OpenTap.Metrics.UnitTest\OpenTap.Metrics.UnitTest.csproj", "{A15E3E1A-961D-4103-9547-62A8F06993EA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTap.Metrics.Nats", "OpenTap.Metrics.Nats\OpenTap.Metrics.Nats.csproj", "{1FE4AE27-797F-4189-BE49-B3A496EA23C5}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestMetrics", "TestMetrics\TestMetrics.csproj", "{479F518F-000F-4AAA-8A01-0133148880F5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,5 +31,9 @@ Global
 		{1FE4AE27-797F-4189-BE49-B3A496EA23C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FE4AE27-797F-4189-BE49-B3A496EA23C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FE4AE27-797F-4189-BE49-B3A496EA23C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{479F518F-000F-4AAA-8A01-0133148880F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{479F518F-000F-4AAA-8A01-0133148880F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{479F518F-000F-4AAA-8A01-0133148880F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{479F518F-000F-4AAA-8A01-0133148880F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/OpenTap.Metrics/MetricInfo.cs
+++ b/OpenTap.Metrics/MetricInfo.cs
@@ -8,7 +8,15 @@ using System.ComponentModel;
 using System.Linq;
 
 namespace OpenTap.Metrics;
-  
+
+internal class AbstractMetricInfo : MetricInfo
+{
+    public new Type Source { get; }
+    public AbstractMetricInfo(IMemberData mem, string groupName, Type source) : base(mem, groupName, source)
+    {
+        Source = source;
+    } 
+}
 /// <summary> Information about a given metric, </summary>
 public class MetricInfo
 {

--- a/OpenTap.Metrics/MetricInfo.cs
+++ b/OpenTap.Metrics/MetricInfo.cs
@@ -15,7 +15,7 @@ internal class AbstractMetricInfo : MetricInfo
     public AbstractMetricInfo(IMemberData mem, string groupName, Type source) : base(mem, groupName, source)
     {
         Source = source;
-    } 
+    }
 }
 /// <summary> Information about a given metric, </summary>
 public class MetricInfo
@@ -55,7 +55,7 @@ public class MetricInfo
     public IEnumerable<object> Attributes { get; }
 
     /// <summary> Gets the full name of the metric. </summary>
-    public string MetricFullName => $"{GroupName} / {Name}";
+    public string MetricFullName => string.IsNullOrEmpty(GroupName) ? Name : $"{GroupName} \\ {Name}";
 
 
     /// <summary> Indicates if the metric is available. </summary>
@@ -66,6 +66,7 @@ public class MetricInfo
     /// This is a hint to the client. A UI is free to ignore this hint.
     /// </summary>
     public bool DefaultEnabled { get; protected set; } = false;
+    public string Unit => Attributes.OfType<UnitAttribute>().FirstOrDefault()?.Unit;
 
     /// <summary> Creates a new metric info based on a member name. </summary>
     /// <param name="mem">The metric member object.</param>

--- a/OpenTap.Metrics/MetricKind.cs
+++ b/OpenTap.Metrics/MetricKind.cs
@@ -10,9 +10,11 @@ namespace OpenTap.Metrics;
 public enum MetricKind
 {
     /// <summary> This metric can be polled. </summary>
+    [Display("Poll", "This metric can be polled.")]
     Poll = 1,
     /// <summary> This metric can be pushed out of band. </summary>
+    [Display("Push", "This metric can be pushed.")]
     Push = 2,
     /// <summary> This metric can be polled and pushed out of band. </summary>
-    PushPoll = Push | Poll,
+    [Display("Push & Poll", "This metric can be pushed and polled.")]PushPoll = Push | Poll,
 }

--- a/OpenTap.Metrics/OpenTap.Metrics.csproj
+++ b/OpenTap.Metrics/OpenTap.Metrics.csproj
@@ -34,6 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />
+    <OpenTapPackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />
   </ItemGroup>
 
 

--- a/OpenTap.Metrics/Settings/MetricInfoTypeDataProvider.cs
+++ b/OpenTap.Metrics/Settings/MetricInfoTypeDataProvider.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+
+namespace OpenTap.Metrics.Settings;
+
+public class MetricInfoTypeDataProvider : ITypeDataProvider
+{
+    private static readonly TraceSource log = Log.CreateSource("Metric Serializer");
+
+    public ITypeData GetTypeData(string identifier)
+    {
+        if (identifier.StartsWith(MetricInfoTypeData.MetricTypePrefix))
+        {
+            var id = identifier.Substring(MetricInfoTypeData.MetricTypePrefix.Length);
+            var info = MetricManager.GetMetricInfos()
+                .FirstOrDefault(m => m.MetricFullName == id);
+            if (info != null)
+            {
+                return MetricInfoTypeData.FromMetricInfo(info);
+            }
+
+            log.ErrorOnce(identifier, $"Metric '{id}' not found.");
+        }
+
+        return null;
+    }
+
+    public ITypeData GetTypeData(object obj)
+    {
+        if (obj is MetricInfo m)
+            return MetricInfoTypeData.FromMetricInfo(m);
+        return null;
+    }
+
+    public double Priority => 999;
+}

--- a/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
+++ b/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using OpenTap.Package;
+
+namespace OpenTap.Metrics.Settings;
+
+public class MetricInfoTypeDataSearcher : ITypeDataSearcherCacheInvalidated, ITypeDataSourceProvider
+{
+    private InstrumentSettings prevInstruments = null;
+    private DutSettings prevDuts = null;
+    void SetupAndSearch(object a, object b)
+    {
+        // Update all handlers. If any settings instances were changed
+        if (prevInstruments != null)
+        {
+            prevInstruments.CacheInvalidated -= SetupAndSearch;
+            prevInstruments.CollectionChanged -= SetupAndSearch;
+            prevInstruments.PropertyChanged -= SetupAndSearch;
+        }
+
+        if (prevDuts != null)
+        {
+            prevDuts.CacheInvalidated -= SetupAndSearch;
+            prevDuts.CollectionChanged -= SetupAndSearch;
+            prevDuts.PropertyChanged -= SetupAndSearch; 
+        }
+
+        var ins = InstrumentSettings.Current;
+        var duts = DutSettings.Current;
+        ins.CacheInvalidated += SetupAndSearch;
+        ins.CollectionChanged += SetupAndSearch;
+        ins.PropertyChanged += SetupAndSearch;
+        duts.CacheInvalidated += SetupAndSearch;
+        duts.CollectionChanged += SetupAndSearch;
+        duts.PropertyChanged += SetupAndSearch;
+        prevInstruments = ins;
+        prevDuts = duts; 
+        Search();
+    }
+    public MetricInfoTypeDataSearcher()
+    {
+        SetupAndSearch(null, null);
+    }
+
+    private long updateStarted = 0;
+
+    private void Search2(object a, object b)
+    {
+        Search();
+    }
+    public void Search()
+    {
+        // Postpone updates while they happen within this interval
+        const int debounce_ms = 200;
+        // Don't postpone the update indefinitely..
+        const int debounce_max_ms = 10000;
+        var processingToken = Interlocked.Increment(ref updateStarted);
+        if (processingToken != 1) return;
+        
+        // We need to search in a thread because GetMetricInfos() will cause a recursive call which will deadlock otherwise.
+        TapThread.Start(() =>
+        {
+            try
+            {
+                var sw = Stopwatch.StartNew();
+                while (sw.Elapsed < TimeSpan.FromMilliseconds(debounce_max_ms))
+                {
+                    var prev = updateStarted;
+                    TapThread.Sleep(debounce_ms);
+                    if (prev == updateStarted) break;
+                }
+                Infos = MetricManager.GetMetricInfos().Concat(MetricManager.GetAbstractMetricInfos()).ToList();
+                var changers = Infos.Select(i => i.Source).OfType<INotifyPropertyChanged>().Distinct();
+                foreach (var ch in changers)
+                {
+                    ch.PropertyChanged -= Search2;
+                    ch.PropertyChanged += Search2;
+                }
+                CacheInvalidated?.Invoke(this, new());
+                long token2 = Interlocked.Exchange(ref updateStarted, 0);
+                if (token2 != 1)
+                {
+                    // a search was inititated during sleep
+                    Search();
+                }
+            }
+            catch
+            {
+                Interlocked.Exchange(ref updateStarted, 0); 
+            }
+        });
+    } 
+
+    private List<MetricInfo> Infos { get; set; } = new(); 
+
+
+    // It is tricky to filter away metrics that are currently configured for several reasons:
+    // 1. Checking the currently configured metrics causes recursive typedata lookups, which can deadlock
+    // 2. This can be called in other situations to discover specializations of IMetricInfo. If a configured MetricInfo
+    // is not recognized as a specialization, we can run into weird behavior.
+    public IEnumerable<ITypeData> Types => Infos.Select(MetricInfoTypeData.FromMetricInfo);
+    public ITypeDataSource GetSource(ITypeData typeData)
+    {
+        if (typeData is MetricInfoTypeData m)
+        {
+            return new MetricTypeDataSource(m);
+        }
+
+        return null;
+    }
+
+    class MetricTypeDataSource : ITypeDataSource
+    {
+        public string Name => td.Name;
+        public string Location => td.SourceAssembly.Location;
+
+        public IEnumerable<ITypeData> Types => td.GetRelatedMetrcInfoTypeDatas();
+        public IEnumerable<object> Attributes => td.Attributes;
+        public IEnumerable<ITypeDataSource> References => [];
+        public string Version { get; }
+
+        private readonly MetricInfoTypeData td;
+        public MetricTypeDataSource(MetricInfoTypeData td)
+        {
+            this.td = td;
+            Version = Installation.Current.FindPackageContainingFile(td.SourceAssembly.Location)?.Version?.ToString() ??
+                      "1.0.0";
+        }
+    }
+
+    public event EventHandler<TypeDataCacheInvalidatedEventArgs> CacheInvalidated;
+}
+
+class MetricInfoTypeData : ITypeData
+{
+    public const string MetricTypePrefix = "met:";
+    public MetricInfo MetricInfo { get; }
+    private static ConditionalWeakTable<MetricInfo, MetricInfoTypeData> _cache = new();
+    private static ConditionalWeakTable<Assembly, ConcurrentBag<MetricInfoTypeData>> _sourceLookup = new();
+    public static MetricInfoTypeData FromMetricInfo(MetricInfo source)
+    {
+        return _cache.GetValue(source, _ => new MetricInfoTypeData(source));
+    }
+
+    internal Assembly SourceAssembly => (MetricInfo as AbstractMetricInfo)?.Source.Assembly ?? MetricInfo.Source.GetType().Assembly;
+
+    private MetricInfoTypeData(MetricInfo metricInfo)
+    {
+        this.MetricInfo = metricInfo;
+        this.BaseType = TypeData.FromType(typeof(MetricsSettingsItem));
+        var bag = _sourceLookup.GetValue(SourceAssembly, _ => new());
+        bag.Add(this); 
+    }
+
+    internal IEnumerable<MetricInfoTypeData> GetRelatedMetrcInfoTypeDatas() =>
+        _sourceLookup.GetValue(SourceAssembly, _ => [this]);
+
+    private DisplayAttribute displayAttribute = null;
+
+    private ITypeData innerType => BaseType;
+    public bool IsAbstract => MetricInfo is AbstractMetricInfo;
+    public IEnumerable<object> Attributes => [ new BrowsableAttribute(ShouldBeBrowsable), displayAttribute ??= new DisplayAttribute(MetricInfo.Name, Group: MetricInfo.GroupName) , ..innerType.Attributes];
+
+    private bool ShouldBeBrowsable => !IsAbstract && !MetricsSettings.Current.Any(m => Equals(m.Metric, MetricInfo));
+    public string Name => $"{MetricTypePrefix}{MetricInfo.MetricFullName}";
+
+    public IEnumerable<IMemberData> GetMembers()
+    {
+        return innerType.GetMembers();
+    }
+
+    public IMemberData GetMember(string name)
+    {
+        return innerType.GetMember(name);
+    }
+
+    public object CreateInstance(object[] arguments)
+    {
+        if (IsAbstract)
+            throw new Exception($"Cannot instantiate an abstract metric.");
+        return new MetricsSettingsItem(MetricInfo);
+    }
+
+    public ITypeData BaseType { get; }
+
+    // This plugin type will not be added to a plugins package xml if it cannot be instantiated.
+    // If this metric requires a concrete instrument, we should still advertise being able to instantiate it,
+    // but add [Unbrowsable] to the abstract type. The concrete type can still be instantiated normally.
+    public bool CanCreateInstance => true;
+}

--- a/OpenTap.Metrics/Settings/MetricStartupHook.cs
+++ b/OpenTap.Metrics/Settings/MetricStartupHook.cs
@@ -25,7 +25,7 @@ public class EnsureMetricsBrowsableAction : ICustomPackageAction
         {
             foreach (var plugin in file.Plugins)
             {
-                if (plugin.Name.StartsWith(MetricInfoTypeData.MetricTypePrefix))
+                if (plugin.Type.StartsWith(MetricInfoTypeData.MetricTypePrefix))
                 {
                     plugin.Browsable = true;
                 }

--- a/OpenTap.Metrics/Settings/MetricStartupHook.cs
+++ b/OpenTap.Metrics/Settings/MetricStartupHook.cs
@@ -1,0 +1,9 @@
+namespace OpenTap.Metrics.Settings;
+
+public class MetricStartupHook : IStartupInfo
+{
+    public void LogStartupInfo()
+    {
+        MetricInfoTypeDataSearcher.InitialInfos = [.. MetricManager.GetMetricInfos(), ..MetricManager.GetAbstractMetricInfos()];
+    }
+}

--- a/OpenTap.Metrics/Settings/MetricStartupHook.cs
+++ b/OpenTap.Metrics/Settings/MetricStartupHook.cs
@@ -1,3 +1,9 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenTap.Package;
+
 namespace OpenTap.Metrics.Settings;
 
 public class MetricStartupHook : IStartupInfo
@@ -6,4 +12,27 @@ public class MetricStartupHook : IStartupInfo
     {
         MetricInfoTypeDataSearcher.InitialInfos = [.. MetricManager.GetMetricInfos(), ..MetricManager.GetAbstractMetricInfos()];
     }
+}
+
+public class EnsureMetricsBrowsableAction : ICustomPackageAction
+{
+    public int Order() => 999;
+    
+
+    public bool Execute(PackageDef package, CustomPackageActionArgs customActionArgs)
+    {
+        foreach (var file in package.Files)
+        {
+            foreach (var plugin in file.Plugins)
+            {
+                if (plugin.Name.StartsWith(MetricInfoTypeData.MetricTypePrefix))
+                {
+                    plugin.Browsable = true;
+                }
+            }
+        }
+        return true;
+    }
+
+    public PackageActionStage ActionStage => PackageActionStage.Create;
 }

--- a/OpenTap.Metrics/Settings/MetricsSettings.cs
+++ b/OpenTap.Metrics/Settings/MetricsSettings.cs
@@ -8,17 +8,27 @@ namespace OpenTap.Metrics.Settings;
 public interface IMetricsSettingsItem : ITapPlugin
 {
     public MetricInfo Metric { get; }
+    public int PollRate { get; }
 }
 
 [Display("Metric", "The configuration for a specific metric.")]
-public class MetricsSettingsItem : IMetricsSettingsItem
+[Browsable(false)]
+public class MetricsSettingsItem : ValidatingObject, IMetricsSettingsItem
 {
+    // KS8400 uses `ToString()` to get the name of this item
+    // Runner gets the `Name` property with reflection
     public override string ToString() => Name;
-    public string Name => Metric?.MetricFullName ?? "Unknown";
-    private string _selectedMetricString;
 
+    [Browsable(true)]
+    [Display("Group", "The group of this metric.", Order: 1.0)]
+    public string MetricGroup => Metric?.GroupName ?? "Unknown";
+    [Browsable(true)]
+    [Display("Name", "The name of this metric.", Order: 1.1)]
+    public string Name => Metric?.Name ?? "Unknwon";
+
+    private string _selectedMetricString;
     [Display("Metric", "The full name of this metric.", Order: 1)]
-    [AvailableValues(nameof(AvailableMetricNames))]
+    [Browsable(false)]
     public string SelectedMetricString
     {
         get => _selectedMetricString;
@@ -26,7 +36,7 @@ public class MetricsSettingsItem : IMetricsSettingsItem
         {
             if (_selectedMetricString == value) return;
             _selectedMetricString = value;
-            Metric = getSelectedMetric();
+            Metric = MetricManager.GetMetricByName(value);
             if (CanPoll)
             {
                 var pollrate = Metric.DefaultPollRate == 0 ? 300 : Metric.DefaultPollRate;
@@ -41,7 +51,7 @@ public class MetricsSettingsItem : IMetricsSettingsItem
 
     /// <summary> The type of this metric. </summary>
     [Browsable(true)]
-    [Display("Type", Description: "The type of this metric.", Order: 3)]
+    [Display("Type", "The type of this metric.", Order: 3)]
     public MetricType Type => Metric.Type;
 
     /// <summary> Whether this metric can be polled or will be published out of band. </summary>
@@ -49,8 +59,8 @@ public class MetricsSettingsItem : IMetricsSettingsItem
     public MetricKind Kind => Metric.Kind;
 
     [Browsable(false)]
-    public int[] SuggestedPollRates => new int[] { 5, 10, 30, 60, 300, 900, 1800, 3600, 7200, 86400 }
-        .Concat(Metric.DefaultPollRate == 0 ? [] : [Metric.DefaultPollRate]).OrderBy(x => x).Distinct().ToArray();
+    [XmlIgnore]
+    public List<int> SuggestedPollRates { get; private set; }
 
     private string secondsToReadableString(int v)
     {
@@ -78,13 +88,12 @@ public class MetricsSettingsItem : IMetricsSettingsItem
     }
 
     [Browsable(false)] public bool CanPoll => Metric?.Kind.HasFlag(MetricKind.Poll) ?? false;
-
-    string[] getSuggestedPollRateStrings()
+    string[] getPollRates()
     {
         if (!CanPoll)
             return ["Disabled"];
         var spr = SuggestedPollRates;
-        var strings = new string[spr.Length];
+        var strings = new string[spr.Count];
         for (int i = 0; i < strings.Length; i++)
         {
             var pollrate = spr[i];
@@ -98,7 +107,9 @@ public class MetricsSettingsItem : IMetricsSettingsItem
 
     [Browsable(false)] public int PollRate => SuggestedPollRates[AvailablePollRateStrings.IndexOf(PollRateString)];
 
-    [Browsable(false)] public string[] AvailablePollRateStrings { get; set; }
+    [Browsable(false)]
+    [XmlIgnore]
+    public string[] AvailablePollRateStrings { get; private set; }
 
     private string _pollRateString;
 
@@ -116,43 +127,6 @@ public class MetricsSettingsItem : IMetricsSettingsItem
         }
     }
 
-    private MetricInfo[] getAvailableMetrics()
-    {
-        var infos = MetricManager.GetMetricInfos().ToList();
-        for (int i = infos.Count - 1; i >= 0; i--)
-        {
-            var m = infos[i];
-            if (m.MetricFullName == SelectedMetricString) continue;
-            try
-            {
-                if (MetricsSettings.Current.Any(x => x.Metric?.MetricFullName == m.MetricFullName))
-                    infos.RemoveAt(i);
-            }
-            catch
-            {
-                // ignore
-            }
-        }
-
-        return infos.ToArray();
-    }
-
-    public MetricInfo[] AvailableMetrics => getAvailableMetrics();
-    [Browsable(false)] public string[] AvailableMetricNames => AvailableMetrics.Select(m => m.MetricFullName).ToArray();
-
-    private MetricInfo getSelectedMetric()
-    {
-        if (AvailableMetrics is { Length: > 0 })
-        {
-            var idx = AvailableMetricNames.IndexOf(SelectedMetricString);
-            if (idx >= 0 && idx < AvailableMetrics.Length)
-            {
-                return AvailableMetrics[idx];
-            }
-        }
-
-        return null;
-    }
 
     private MetricInfo _metric;
 
@@ -161,16 +135,40 @@ public class MetricsSettingsItem : IMetricsSettingsItem
     public MetricInfo Metric
     {
         get => _metric;
-        set
+        private set
         {
+            if (Equals(_metric, value)) return;
             _metric = value;
-            AvailablePollRateStrings = getSuggestedPollRateStrings();
+            List<int> defaultPollRates = [5, 10, 30, 60, 300, 900, 1800, 3600, 7200, 86400];
+            if (_metric.DefaultPollRate != 0)
+            {
+                var insertAt = defaultPollRates.FindIndex(i => i > _metric.DefaultPollRate);
+                if (insertAt == -1) insertAt = defaultPollRates.Count;
+                defaultPollRates.Insert(insertAt, _metric.DefaultPollRate);
+            }
+            SuggestedPollRates = defaultPollRates;
+            AvailablePollRateStrings = getPollRates();
         }
     }
 
     public MetricsSettingsItem()
     {
-        SelectedMetricString = AvailableMetricNames.FirstOrDefault();
+    }
+
+    public MetricsSettingsItem(MetricInfo metric)
+    {
+        SelectedMetricString = metric.MetricFullName;
+    }
+
+    protected override string GetError(string propertyName = null)
+    {
+        if (propertyName == nameof(SelectedMetricString))
+        {
+            if (MetricsSettings.Current.Any(m => !ReferenceEquals(this, m) && m.Metric?.MetricFullName == Metric?.MetricFullName))
+                return "Metric has duplicate entries.";
+        }
+
+        return null;
     }
 }
 
@@ -178,4 +176,14 @@ public class MetricsSettingsItem : IMetricsSettingsItem
 [Display("Metrics", "List of enabled metrics that should be monitored.")]
 public class MetricsSettings : ComponentSettingsList<MetricsSettings, IMetricsSettingsItem>
 {
+    public override void Initialize()
+    {
+        // TODO: Handle when new Instruments / DUTs are added to the bench (default metrics should be added)
+        // TODO: Handle when Instruments / DUTs are removed from the bench (metrics from such sources should be removed)
+        // TODO: Handle when a plugin providing metrics is uninstalled.
+        foreach (var defaultMetric in MetricManager.GetMetricInfos().Where(m => m.DefaultEnabled))
+        {
+            Add(new MetricsSettingsItem(defaultMetric));
+        }
+    }
 }

--- a/TestMetrics/RegularMetricSource.cs
+++ b/TestMetrics/RegularMetricSource.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenTap;
+using OpenTap.Metrics;
+using OpenTap.Metrics.Settings;
+using OpenTap.Package;
+
+namespace TestMetrics;
+
+[Display("Regular Metric Source")]
+public class RegularMetricSource : IMetricSource
+{
+    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 27)]
+    public int PollMetric { get; set; }
+    
+    [Metric("Push Metric", kind: MetricKind.Push, DefaultPollRate = 120)]
+    public int PushMetric { get; set; }
+    
+    [Metric("PushPoll Metric", kind: MetricKind.PushPoll, DefaultPollRate = 1200)]
+    public int PushPollMetric { get; set; } 
+    
+    [Metric("Quick Metric", kind: MetricKind.Poll, DefaultPollRate = 1)]
+    public int QuickMetric { get; set; }
+    [Metric("Slow Metric", kind: MetricKind.Poll, DefaultPollRate = 86400*100)]
+    public int SlowMetric { get; set; }
+}
+
+[Display("Instrument Metric Source")]
+public class InstrumentMetricSource : Instrument, IMetricSource
+{
+    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 27)]
+    public int PollMetric { get; set; }
+    
+    [Metric("Push Metric", kind: MetricKind.Push, DefaultPollRate = 120)]
+    public int PushMetric { get; set; }
+    
+    [Metric("PushPoll Metric", kind: MetricKind.PushPoll, DefaultPollRate = 1200)]
+    public int PushPollMetric { get; set; } 
+}
+
+public class AfterCreateAction : ICustomPackageAction
+{
+    public int Order() => 999;
+    
+
+    public bool Execute(PackageDef package, CustomPackageActionArgs customActionArgs)
+    {
+        var tds = TypeData.GetDerivedTypes<IMetricsSettingsItem>().ToArray();
+        using var ms = new MemoryStream();
+        package.SaveTo(ms);
+        var str = Encoding.UTF8.GetString(ms.ToArray());
+        Console.WriteLine(str);
+        return true;
+    }
+
+    public PackageActionStage ActionStage => PackageActionStage.Create;
+}

--- a/TestMetrics/TestMetrics.csproj
+++ b/TestMetrics/TestMetrics.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    
+    <PropertyGroup>
+        <OpenTapPackageDefinitionPath>package.xml</OpenTapPackageDefinitionPath>
+        <CreateOpenTapPackage>false</CreateOpenTapPackage>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)"/>
+        <ProjectReference Include="..\OpenTap.Metrics\OpenTap.Metrics.csproj" />
+        <OpenTapPackageReference Include="OpenTAP" Version="$(OpenTapVersion)"/>
+    </ItemGroup>
+
+</Project>

--- a/TestMetrics/package.xml
+++ b/TestMetrics/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+InfoLink: Specifies a location where additional information about the package can be found.
+Version: The version of the package. Must be in a semver 2.0 compatible format. This can be automatically updated from GIT.
+
+For Version the following macro is available (Only works if the project directory is under Git source control):
+$(GitVersion) - Gets the version from Git in the recommended format Major.Minor.Build-PreRelease+CommitHash.BranchName.
+-->
+<Package Name="TestMetrics" xmlns="http://opentap.io/schemas/package" InfoLink="" Version="$(GitVersion)" OS="Windows,Linux,MacOS">
+  <Description>This plugin provides interfaces to publish, poll, and subscribe to metrics.</Description>
+  <Owner>OpenTAP</Owner>
+  <SourceUrl>https://github.com/opentap/OpenTap.Metrics</SourceUrl>
+  <SourceLicense>MPL-2.0</SourceLicense>
+  <Dependencies>
+    <PackageDependency Package="OpenTAP" Version="^9.16.4+654f0b6b" />
+  </Dependencies>
+  <Files>
+    <File Path="Packages/TestMetrics/TestMetrics.dll" SourcePath="TestMetrics.dll">
+<!--        <Sign Certificate="Keysight Technologies, Inc."/>-->
+        <!-- This is being set automatically in the .csproj  -->
+        <!-- <SetAssemblyInfo Attributes="Version"/> -->
+    </File>
+  </Files>
+</Package>


### PR DESCRIPTION
This adds support for installing plugins providing metrics through the 'Add New' menu

It also revamps MetricSettings so the metric is selected during 'Add', instead of being selected after a row has already been added