### PR TITLE
Changed name of metric metadata to "AssetID" …

### DIFF
--- a/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
+++ b/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
@@ -472,11 +472,11 @@ public class MetricManagerTest
             Assert.That(m.MetaData["Model"], Is.EqualTo("N9020"));
             if (m.Info.Source == mxa1)
             {
-                Assert.That(m.MetaData["ID"], Is.EqualTo($"{mxa1.Manufacturer}{mxa1.Model}{mxa1.SerialNumber}"));
+                Assert.That(m.MetaData["AssetID"], Is.EqualTo($"{mxa1.Manufacturer}{mxa1.Model}{mxa1.SerialNumber}"));
             }
             else
             {
-                Assert.That(m.MetaData["ID"], Is.EqualTo($"{mxa2.Manufacturer}{mxa2.Model}{mxa2.SerialNumber}"));
+                Assert.That(m.MetaData["AssetID"], Is.EqualTo($"{mxa2.Manufacturer}{mxa2.Model}{mxa2.SerialNumber}"));
             }
         }
     }

--- a/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
+++ b/OpenTap.Metrics/AssetDiscovery/IAssetDiscovery.cs
@@ -143,6 +143,6 @@ public interface IAsset
     /// A unique identifier for the asset. This is used to identify the asset in the system.
     /// E.g. for an Instrument, this could be a combination of Manufacturer, Model and serial number.
     /// </summary>
-    [MetaData(Name = "ID")]
+    [MetaData(Name = "AssetID")] // Don't change this name as it is used to associate metrics with the asset.
     string Identifier { get; }
 }


### PR DESCRIPTION
now that KS8500 is going to depend on this this metadata for ascosiating metrics to a specific asset, we better have a clear name for it. "ID" was just too easy to clash with.