### PR TITLE
Detect deleted metrics

### DIFF
--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -109,7 +108,8 @@ public static class MetricManager
             }
         }
 
-        foreach (var metricSource in producers.Concat(InstrumentSettings.Current).Concat(DutSettings.Current))
+        var sources = producers.Concat(InstrumentSettings.Current).Concat(DutSettings.Current);
+        foreach (var metricSource in sources)
         {
 
             var type1 = TypeData.GetTypeData(metricSource);
@@ -376,9 +376,9 @@ public static class MetricManager
         _pushMetricInfos[metricInfo.Member] = metricInfo;
     }
 
-    private static readonly ConcurrentDictionary<string, MetricInfo> metricNameLookup = new();
     internal static MetricInfo GetMetricByName(string value)
     {
-        return metricNameLookup.GetOrAdd(value, _ => GetMetricInfos().FirstOrDefault(m => m.MetricFullName == value));
+        if (string.IsNullOrWhiteSpace(value)) return null;
+        return GetMetricInfos().FirstOrDefault(m => m.MetricFullName == value);
     }
 }

--- a/OpenTap.Metrics/Settings/MetricsSettingsSerializer.cs
+++ b/OpenTap.Metrics/Settings/MetricsSettingsSerializer.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Xml.Linq;
+
+namespace OpenTap.Metrics.Settings;
+
+public class MetricsSettingsSerializer : TapSerializerPlugin
+{
+    public override bool Deserialize(XElement node, ITypeData t, Action<object> setter)
+    {
+        if (t.DescendsTo(typeof(IMetricsSettingsItem)))
+        {
+            var fullPath = node.Element(nameof(MetricsSettingsItem.MetricFullName))?.Value ?? null;
+            var metricInfo = MetricManager.GetMetricByName(fullPath);
+            if (metricInfo == null)
+            {
+                var msg = $"Missing metric '{fullPath}'. Has the resource or plugin for this metric been removed?";
+                Serializer.PushError(node, msg);
+            }
+            else
+            {
+                setter(new MetricsSettingsItem(metricInfo));
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    public override bool Serialize(XElement node, object obj, ITypeData expectedType)
+    {
+        return false;
+    }
+
+    public double Order => 999;
+}

--- a/TestMetrics/RegularMetricSource.cs
+++ b/TestMetrics/RegularMetricSource.cs
@@ -2,7 +2,9 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using OpenTap;
+using OpenTap.Cli;
 using OpenTap.Metrics;
 using OpenTap.Metrics.Settings;
 using OpenTap.Package;
@@ -30,7 +32,7 @@ public class RegularMetricSource : IMetricSource
 [Display("Instrument Metric Source")]
 public class InstrumentMetricSource : Instrument, IMetricSource
 {
-    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 27)]
+    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 27, DefaultEnabled = true)]
     public int PollMetric { get; set; }
     
     [Metric("Push Metric", kind: MetricKind.Push, DefaultPollRate = 120)]


### PR DESCRIPTION
This removes a lot of getter/setter complexity from metrics settings by doing all the work in the constructor, and not allowing changing Metrics for a specific item.

This required some serializer support, which also gives us the opportunity to give nice error messages when previously configured metrics are no longer available, similar to other kinds of resources.


Example error message when a metric from an instrument is no longer available because the instrument was removed:

![image](https://github.com/user-attachments/assets/ebc7ade8-30f1-4377-acd9-23817deb791f)
