### PR TITLE
avoid serializing merged metric information

### DIFF
--- a/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
+++ b/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
@@ -22,25 +22,10 @@ public class MetricInfoTypeDataSearcher : ITypeDataSearcherCacheInvalidated, ITy
         {
             try
             {
-                HashSet<MetricSpecifier> uniqueMetrics = [];
-                var groups = TypeData.GetDerivedTypes<IMetricSource>().SelectMany(src => src.GetMetricMembers())
-                    .GroupBy(x => new MetricSpecifier(x));
-                foreach (var grp in groups)
-                {
-                    MetricSpecifier d = new MetricSpecifier(grp.Key.Name, grp.Key.Group, grp.Key.Type);
-                    foreach (var g in grp)
-                    {
-                        var attr = g.GetAttribute<MetricAttribute>();
-                        if (attr.DefaultPollRate != 0) d.DefaultPollRate = attr.DefaultPollRate;
-                        if (attr.DefaultEnabled) d.DefaultEnabled = true;
-                        if (attr.Kind.HasFlag(MetricKind.Poll)) d.Kind |= MetricKind.Poll;
-                        if (attr.Kind.HasFlag(MetricKind.Push)) d.Kind |= MetricKind.Push;
-                    }
-
-                    uniqueMetrics.Add(d);
-                }
-
-                metricSpecifiers = uniqueMetrics.ToArray();
+                metricSpecifiers = TypeData.GetDerivedTypes<IMetricSource>().SelectMany(src => src.GetMetricMembers())
+                    .Select(x => new MetricSpecifier(x))
+                    .Distinct()
+                    .ToArray();
                 CacheInvalidated?.Invoke(this, new());
             }
             finally

--- a/OpenTap.Metrics/Settings/MetricSpecifier.cs
+++ b/OpenTap.Metrics/Settings/MetricSpecifier.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace OpenTap.Metrics.Settings;
 
@@ -6,29 +9,20 @@ public class MetricSpecifier : IEquatable<MetricSpecifier>
 {
     public bool Matches(MetricInfo i)
     {
-        var attr = i.Member.GetAttribute<MetricAttribute>();
-        var grp = string.IsNullOrWhiteSpace(attr.Group) ? null : attr.Group;
-        return i.Name == Name && grp == Group && i.Type.HasFlag(Type);
+        return new MetricSpecifier(i.Member).Equals(this);
     }
     public override string ToString()
     {
         if (string.IsNullOrWhiteSpace(Group)) return $"{Type} \\ {Name}";
         return $"{Type} \\ {Group} \\ {Name}";
-    }
+    } 
 
     public string Name { get; set; }
     public string Group { get; set; }
     public MetricType Type { get; set; }
-    public MetricKind Kind { get; set; }
-    public bool DefaultEnabled { get; set; }
-    public int DefaultPollRate { get; set; }
-
-    public MetricSpecifier(string name, string group, MetricType type)
-    {
-        Name = name;
-        Group = group;
-        Type = type;
-    }
+    public MetricKind Kind => _mergedMetricInfo.Kind;
+    public bool DefaultEnabled => _mergedMetricInfo.DefaultEnabled;
+    public List<int> DefaultPollRates => _mergedMetricInfo.DefaultPollRates;
 
     public MetricSpecifier(IMemberData x)
     {
@@ -37,20 +31,26 @@ public class MetricSpecifier : IEquatable<MetricSpecifier>
         Name = attr.Name;
         Group = grp;
         Type = MetricInfo.GetMemberMetricType(x);
+        // Consider two metrics equal regardless of nullability
+        if (Type.HasFlag(MetricType.Nullable))
+            Type -= MetricType.Nullable;
     }
 
     public MetricSpecifier()
     { 
     }
 
-    public bool Equals(MetricSpecifier other)
-    {
-        return Name == other.Name && Group == other.Group && Type == other.Type;
-    }
 
     public override bool Equals(object obj)
     {
-        return obj is MetricSpecifier other && Equals(other);
+        return ReferenceEquals(this, obj) || obj is MetricSpecifier other && Equals(other);
+    }
+    
+    public bool Equals(MetricSpecifier other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Name == other.Name && Group == other.Group && Type == other.Type;
     }
 
     public override int GetHashCode()
@@ -63,4 +63,34 @@ public class MetricSpecifier : IEquatable<MetricSpecifier>
             return hashCode;
         }
     }
+
+    private class MergedMetricInfo
+    {
+        public bool DefaultEnabled;
+        public List<int> DefaultPollRates = new();
+        public MetricKind Kind;
+    }
+
+    private static readonly ConcurrentDictionary<MetricSpecifier, MergedMetricInfo> _cache = new();
+
+    private MergedMetricInfo _mergedMetricInfo => _cache.GetOrAdd(this, static x =>
+    {
+        var mmi = new MergedMetricInfo();
+        var metricSpecifiers = TypeData.GetDerivedTypes<IMetricSource>().SelectMany(src => src.GetMetricMembers())
+            .Where(x2 => new MetricSpecifier(x2).Equals(x))
+            .ToArray();
+        foreach (var g in metricSpecifiers)
+        {
+            var attr = g.GetAttribute<MetricAttribute>();
+            if (attr.DefaultPollRate != 0) mmi.DefaultPollRates.Add(attr.DefaultPollRate);
+            if (attr.DefaultEnabled) mmi.DefaultEnabled = true;
+            if (attr.Kind.HasFlag(MetricKind.Poll)) mmi.Kind |= MetricKind.Poll;
+            if (attr.Kind.HasFlag(MetricKind.Push)) mmi.Kind |= MetricKind.Push;
+        }
+
+        mmi.DefaultPollRates = mmi.DefaultPollRates.Distinct().ToList();
+        mmi.DefaultPollRates.Sort();
+
+        return mmi;
+    }); 
 }

--- a/OpenTap.Metrics/Settings/MetricsSettings.cs
+++ b/OpenTap.Metrics/Settings/MetricsSettings.cs
@@ -1,4 +1,3 @@
-using System.Collections.Specialized;
 using System.Linq;
 
 namespace OpenTap.Metrics.Settings; 

--- a/TestMetrics/RegularMetricSource.cs
+++ b/TestMetrics/RegularMetricSource.cs
@@ -15,7 +15,7 @@ public class RegularMetricSource : IMetricSource
     [Metric("Grouped Metric", "Metric Group", kind: MetricKind.Poll, DefaultPollRate = 27)]
     public int GroupedPollMetric { get; set; }
     
-    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 27)]
+    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 25)]
     public int PollMetric { get; set; }
     
     [Metric("Push Metric", kind: MetricKind.Push, DefaultPollRate = 120)]
@@ -42,7 +42,7 @@ public class InstrumentMetricSource2 : Instrument, IMetricSource
 [Display("Instrument Metric Source")]
 public class InstrumentMetricSource : Instrument, IMetricSource
 {
-    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 27)]
+    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 28)]
     public int PollMetric { get; set; }
     
     [Metric("Push Metric", kind: MetricKind.Push, DefaultPollRate = 120)]


### PR DESCRIPTION
Merged metric information is information about a metric specifier which must be aligned between different metric instances. This data must not be serialized because it depends on the constellation of installed plugins. For example, if a plugin provides CalibrationDate as a Push metric, this could promote CalDate to a PushPoll metric. But if this plugin is later uninstalled, it should be demoted again. This also applies to default metrics / default poll rate of metrics.