### PR TITLE
add example implementation of metric sink

### DIFF
--- a/OpenTap.Metrics.Nats/EnableMetricsPollingEndpoint.cs
+++ b/OpenTap.Metrics.Nats/EnableMetricsPollingEndpoint.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace OpenTap.Metrics.Nats
 {
     public class EnableMetricsPollingEndpoint
@@ -10,13 +12,16 @@ namespace OpenTap.Metrics.Nats
 
         private EnableMetricsPollingResponse SetupMetricsPolling(EnableMetricsPollingRequest request)
         {
+            var pusher = MetricSinkSettings.Current.OfType<NatsMetricPusher>().FirstOrDefault();
             if (request.Enabled)
             {
-                NatsMetricPusher.Start();
+                if (pusher == null)
+                    MetricSinkSettings.Current.Add(new NatsMetricPusher());
             }
             else
             {
-                NatsMetricPusher.Stop();
+                if (pusher != null)
+                    MetricSinkSettings.Current.Remove(pusher);
             }
 
             return new EnableMetricsPollingResponse

--- a/OpenTap.Metrics.Nats/NatsMetricPusher.cs
+++ b/OpenTap.Metrics.Nats/NatsMetricPusher.cs
@@ -1,101 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Timers;
 using NATS.Client.Internals;
 using NATS.Client.JetStream;
 using Newtonsoft.Json;
-using OpenTap.Metrics.Settings;
 
 namespace OpenTap.Metrics.Nats
 {
-    public static class Linq2
+    public class NatsMetricPusher : IMetricSink
     {
-        public static IEnumerable<T> DistinctBy<T, T2>(this IEnumerable<T> source, Func<T, T2> selector)
-            where T2 : IEquatable<T2>
+        public NatsMetricPusher()
         {
-            HashSet<T2> occurrences = new HashSet<T2>();
-            foreach (var s in source)
-            {
-                if (occurrences.Add(selector(s)))
-                    yield return s;
-            }
+            SetupMetricsStream();
         }
-    }
-    
-    public class NatsMetricPusher
-    {
         internal const string MetricsStreamName = "Metric";
 
         private static readonly TraceSource log = Log.CreateSource("Metrics");
-        private static readonly NatsMetricPusher instance = new NatsMetricPusher();
 
-        private IJetStream _jetStream;
-        private Timer timer;
-
-        public static void Start()
-        {
-            try
-            {
-                instance.SetupMetricsStream();
-                instance.timer = new Timer()
-                {
-                    Interval = 1000,
-                    AutoReset = true
-                };
-                instance.timer.Elapsed += instance.PollMetrics;
-                instance.timer.Start();
-                log.Info("Metrics polling started.");
-            }
-            catch (Exception e)
-            {
-                log.Error("Error setting up metrics stream");
-                log.Debug(e);
-            }
-        }
-
-        public static void Stop()
-        {
-            instance.timer.Stop();
-            log.Info("Metrics polling stopped.");
-        }
-
-        private void PollMetrics(object sender, ElapsedEventArgs e)
-        {
-            try
-            {
-                if (MetricsSettings.Current.Any())
-                {
-                    long seconds = (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
-                    var pollMetrics = MetricsSettings.Current
-                        .OfType<MetricsSettingsItem>()
-                        .Where(s => s.IsEnabled && seconds % s.PollRate == 0)
-                        .DistinctBy(x => x.Specifier)
-                        .SelectMany(p => p.Metrics)
-                        .Where(m => m.Kind.HasFlag(MetricKind.Poll)).ToList();
-                    if (pollMetrics.Any())
-                    {
-                        log.Debug($"Polling {pollMetrics.Count} metrics.");
-                        var polledMetrics = MetricManager.PollMetrics(pollMetrics);
-                        foreach (var metric in polledMetrics)
-                        {
-                            StoreMetricOnJetStream(metric);
-                        }
-                    }
-                }
-                else
-                {
-                    log.Debug("No metrics enabled.");
-                }
-            }
-            catch (Exception ex)
-            {
-                log.Error($"Error polling metrics: '{ex.Message}'");
-                log.Debug(ex);
-            }
-        }
-
+        private IJetStream _jetStream; 
         private void StoreMetricOnJetStream(IMetric metric)
         {
             var name = escapeSubject(metric.Info.Name);
@@ -146,6 +68,14 @@ namespace OpenTap.Metrics.Nats
             StreamInfo streamInfo = streamNames.Contains(metricsStream.Name) ? jsManagementContext.UpdateStream(metricsStream) : jsManagementContext.AddStream(metricsStream);
             log.Info($"Storage '{metricsStream.Name}' is configured. Currently has {streamInfo.State.Messages} messages");
             _jetStream = RunnerExtension.Connection.CreateJetStreamContext();
+        }
+
+        public void OnMetricsPolled(MetricsPolledEventArgs e)
+        {
+            foreach (var metric in e.Metrics)
+            {
+                StoreMetricOnJetStream(metric);
+            }
         }
     }
 

--- a/OpenTap.Metrics/AutomaticMetricPoller.cs
+++ b/OpenTap.Metrics/AutomaticMetricPoller.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Timers;
+using OpenTap.Metrics.Settings;
+using Timer = System.Timers.Timer;
+
+namespace OpenTap.Metrics;
+
+// public class MetricsPollingStartup : IStartupInfo
+// {
+//     public void LogStartupInfo()
+//     {
+//         AutomaticMetricPoller.Start();
+//     }
+// }
+
+class AutomaticMetricPoller
+{
+    private static long pollToken = 0;
+    private static List<IMetricSink> Sinks = new();
+
+    private static readonly TraceSource log = Log.CreateSource("Metric Poller");
+    private static void UpdateSinks()
+    {
+        var sinkTypes = TypeData.GetDerivedTypes<IMetricSink>()
+            .Where(s => s.CanCreateInstance)
+            .Select(s => s.AsTypeData())
+            .Where(s => s != null)
+            .ToArray();
+        var newSinks = Sinks.ToList();
+        foreach (var t in sinkTypes)
+        {
+            if (newSinks.Any(s => s.GetType() == t.Type))
+                continue;
+            try
+            {
+                if (t.CreateInstance() is IMetricSink sink)
+                    newSinks.Add(sink);
+            }
+            catch (Exception ex)
+            {
+                var displayName = t.GetDisplayAttribute().GetFullName();
+                if(log.ErrorOnce(t.Type, $"Error instantiating sink '{displayName}': {ex.Message}"))
+                    log.Debug(ex); 
+            }
+        }
+
+        Sinks = newSinks;
+    }
+    public static void Start()
+    {
+        var token = Interlocked.Increment(ref pollToken);
+        if (token != 1) return;
+        TapThread.WithNewContext(() =>
+        {
+            TapThread.Start(() =>
+            {
+                PluginManager.PluginsChanged += (x, e) => UpdateSinks();
+                UpdateSinks();
+                var timer = new Timer() { Interval = 1000, AutoReset = true };
+                timer.Elapsed += Tick;
+                timer.Start();
+                TapThread.Current.AbortToken.Register(() => timer.Stop());
+            }, "Metric Poller");
+        });
+    }
+
+    private static void Tick(object sender, ElapsedEventArgs e)
+    {
+        long seconds = (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
+        if (Sinks.Any() && MetricsSettings.Current.Any())
+        {
+            var pollMetrics = MetricsSettings.Current
+                .OfType<MetricsSettingsItem>()
+                .Where(s => s.IsEnabled && seconds % s.PollRate == 0)
+                .DistinctBy(x => x.Specifier)
+                .SelectMany(p => p.Metrics)
+                .Where(m => m.Kind.HasFlag(MetricKind.Poll)).ToList();
+            if (pollMetrics.Any())
+            {
+                log.Debug($"Polling {pollMetrics.Count} metrics.");
+                var metrics = MetricManager.PollMetrics(pollMetrics).ToArray();
+                Parallel.ForEach(Sinks, sink =>
+                {
+                    try
+                    {
+                        sink.OnMetricsPolled(new MetricsPolledEventArgs() { Metrics = metrics });
+                    }
+                    catch (Exception ex)
+                    {
+                        var displayName = TypeData.FromType(sink.GetType()).GetDisplayAttribute().GetFullName();
+                        log.Error($"Unhandled error in sink '{displayName}': {ex.Message}");
+                        log.Debug(ex); 
+                    } 
+                });
+            }
+            
+        }
+    }
+}

--- a/OpenTap.Metrics/IMetricSink.cs
+++ b/OpenTap.Metrics/IMetricSink.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using OpenTap.Package;
+
+namespace OpenTap.Metrics;
+
+/// <summary>
+/// Arguments provided to IMetricSink implementations
+/// </summary>
+public struct MetricsPolledEventArgs
+{
+    public IEnumerable<IMetric> Metrics;
+}
+
+/// <summary>
+/// Public classes implementing this interface will be automatically instantiated by the Metric system,
+/// and receive a callback when metrics configured in MetricsSettings are polled.
+/// </summary>
+public interface IMetricSink : ITapPlugin
+{
+    void OnMetricsPolled(MetricsPolledEventArgs e); 
+}

--- a/OpenTap.Metrics/MetricSinkSettings.cs
+++ b/OpenTap.Metrics/MetricSinkSettings.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Timers;
+using OpenTap.Metrics.Settings;
+
+namespace OpenTap.Metrics;
+
+[Display("Metric Sink Settings", "The configured metric sinks. When sinks are enabled, metrics will automatically be polled in their configured intervals.")]
+public class MetricSinkSettings : ComponentSettingsList<MetricSinkSettings, IMetricSink>
+{
+    private static readonly TraceSource log = Log.CreateSource("Metric Sink");
+    private Timer timer { get; set; }
+    public MetricSinkSettings()
+    { 
+        timer = new Timer() { Interval = 1000, AutoReset = true };
+        timer.Elapsed += Tick;
+        timer.Start();
+    } 
+    ~MetricSinkSettings()
+    {
+        timer.Stop();
+    }
+    private void Tick(object sender, ElapsedEventArgs e)
+    {
+        var sinks = this.ToArray();
+        long seconds = (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
+        if (sinks.Any() && MetricsSettings.Current.Any())
+        {
+            var pollMetrics = MetricsSettings.Current
+                .OfType<MetricsSettingsItem>()
+                .Where(s => s.IsEnabled && seconds % s.PollRate == 0)
+                .DistinctBy(x => x.Specifier)
+                .SelectMany(p => p.Metrics)
+                .Where(m => m.Kind.HasFlag(MetricKind.Poll)).ToList();
+            if (pollMetrics.Any())
+            {
+                log.Debug($"Polling {pollMetrics.Count} metrics.");
+                var metrics = MetricManager.PollMetrics(pollMetrics).ToArray();
+                Parallel.ForEach(sinks, sink =>
+                {
+                    try
+                    {
+                        sink.OnMetricsPolled(new MetricsPolledEventArgs() { Metrics = metrics });
+                    }
+                    catch (Exception ex)
+                    {
+                        var displayName = TypeData.FromType(sink.GetType()).GetDisplayAttribute().GetFullName();
+                        log.Error($"Unhandled error in sink '{displayName}': {ex.Message}");
+                        log.Debug(ex);
+                    }
+                });
+            } 
+        }
+    }
+}

--- a/OpenTap.Metrics/Settings/ExtensionMethods.cs
+++ b/OpenTap.Metrics/Settings/ExtensionMethods.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -19,4 +19,14 @@ internal static class ExtensionMethods
 
     public static IEnumerable<MetricSpecifier> GetMetricSpecifiers(this ITypeData td) =>
         td.GetMetricMembers().Select(x => new MetricSpecifier(x));
+
+    public static IEnumerable<T> DistinctBy<T, T2>(this IEnumerable<T> source, Func<T, T2> selector)
+    {
+        HashSet<T2> occurrences = new HashSet<T2>();
+        foreach (var s in source)
+        {
+            if (occurrences.Add(selector(s)))
+                yield return s;
+        }
+    }
 }

--- a/TestMetrics/AfterCreateAction.cs
+++ b/TestMetrics/AfterCreateAction.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using OpenTap;
+using OpenTap.Metrics.Settings;
+using OpenTap.Package;
+
+namespace TestMetrics;
+
+public class AfterCreateAction : ICustomPackageAction
+{
+    public int Order() => 999;
+    
+
+    public bool Execute(PackageDef package, CustomPackageActionArgs customActionArgs)
+    {
+        var tds = TypeData.GetDerivedTypes<IMetricsSettingsItem>().ToArray();
+        using var ms = new MemoryStream();
+        package.SaveTo(ms);
+        var str = Encoding.UTF8.GetString(ms.ToArray());
+        Console.WriteLine(str);
+        return true;
+    }
+
+    public PackageActionStage ActionStage => PackageActionStage.Create;
+}

--- a/TestMetrics/InstrumentMetricSource.cs
+++ b/TestMetrics/InstrumentMetricSource.cs
@@ -1,0 +1,24 @@
+using OpenTap;
+using OpenTap.Metrics;
+
+namespace TestMetrics;
+
+[Display("Instrument Metric Source")]
+public class InstrumentMetricSource : Instrument, IMetricSource
+{
+    [Metric("Poll Metric", kind: MetricKind.Poll, DefaultPollRate = 27)]
+    public int PollMetric { get; set; }
+    
+    [Metric("Push Metric", kind: MetricKind.Push, DefaultPollRate = 120)]
+    public int PushMetric { get; set; }
+    
+    [Metric("PushPoll Metric", kind: MetricKind.PushPoll, DefaultPollRate = 1200)]
+    public int PushPollMetric { get; set; } 
+}
+
+[Display("Instrument Metric Source 2")]
+public class InstrumentMetricSource2 : Instrument, IMetricSource
+{
+    [Metric("New Unique Metric", DefaultEnabled = true ) ]
+    public int SomeMetric { get; set; }
+}


### PR DESCRIPTION
This implementation contains two variants of metric sinks:
1. A MetricSinkSettings system where sinks are configured separately. This should be a simplification for e.g. the Nats sink because we can configure the nats sink in the default session, and just leave it disabled in other sessions. Then there should be no need for the UI to activate it. This also gives sinks the opportunity to provide config options.
2. A system that automatically instantiates all IMetricSinks at startup. This is maybe a bit simpler (all sinks are always available), but is a lot less flexible.

Todo:
 - [ ] Add support for push metrics. Sinks should automatically be subscribed to all configured push metrics


With this implementation, we have both an `IMetricListener` and an `IMetricSink`. We need to either consolidate this, or clearly delineate them.

A couple of options:

* Break the API and simplify it to only use IMetricSink. This makes some sense to me because the previous design was when we intended for plugins to do all the heavy lifting which is now managed by the Metrics plugin
* Make IMetricSink inherit from IMetricListener. The sink manager will then ensure that sinks are subscribed to configured metrics. This should be simple to support, but the API is getting a bit muddled.

In either case, I think we can improve overall performance of the system quite a bit by making MetricManager consider the Sink Manager as a special metric listener which is subscribed to metrics configured on the bench.

But this raises the question, does anyone need the flexibility the system was originally designed for? Or can we just say that everyone should use the MetricsSettings / Sink system, and completely scrap most of the MetricManager interfaces?