### PR TITLE
Revert name of "Asset Discovery" settings tab

### DIFF
--- a/OpenTap.Metrics/AssetDiscovery/AssetDiscoverySettings.cs
+++ b/OpenTap.Metrics/AssetDiscovery/AssetDiscoverySettings.cs
@@ -2,7 +2,7 @@ using System.Linq;
 
 namespace OpenTap.Metrics.AssetDiscovery;
 
-[Display("Asset Discovery Providers", "List of asset discovery implementations to use.")]
+[Display("Asset Discovery", "List of asset discovery providers to use.")]
 public class AssetDiscoverySettings : ComponentSettingsList<AssetDiscoverySettings, IAssetDiscoveryProvider>
 {
     public override void Initialize()


### PR DESCRIPTION
We were a bit too quick with https://github.com/opentap/MetricsAndAssets/pull/86

The tab should still just be called "Asset Discovery" as per issue here: https://github.com/opentap/ks8500/issues/2202