### PR TITLE
Update metric kind scan to also include IResource types

### DIFF
--- a/OpenTap.Metrics/Settings/MetricInfoTypeDataSource.cs
+++ b/OpenTap.Metrics/Settings/MetricInfoTypeDataSource.cs
@@ -17,7 +17,7 @@ class MetricInfoTypeDataSource : ITypeDataSource
         // just guess. 
 
         // 1. Find all sources
-        var allSources = TypeData.GetDerivedTypes<IMetricSource>().ToArray();
+        var allSources = MetricMemberHelpers.GetAllMetricSources().ToArray();
         // 2. Filter the sources list down to the set of sources that provide this metric
         var metricSources = allSources.Where(x => x.GetMetricSpecifiers().Any(spec =>
             spec.Equals(mtd.Specifier))).ToArray();

--- a/OpenTap.Metrics/Settings/MetricMemberHelpers.cs
+++ b/OpenTap.Metrics/Settings/MetricMemberHelpers.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace OpenTap.Metrics.Settings;
 
-internal static class ExtensionMethods
+internal static class MetricMemberHelpers
 {
     public static int IndexOf<T>(this T[] arr, T elem)
     {
@@ -17,6 +17,12 @@ internal static class ExtensionMethods
     public static IEnumerable<IMemberData> GetMetricMembers(this ITypeData td) =>
         td.GetMembers().Where(mem => mem.HasAttribute<MetricAttribute>());
 
+    public static IEnumerable<ITypeData> GetAllMetricSources() =>
+        TypeData.GetDerivedTypes<IMetricSource>()
+            .Concat(TypeData.GetDerivedTypes<IResource>())
+            .Where(x => x.CanCreateInstance);
+
+    public static IEnumerable<IMemberData> GetAllMetricMembers() => GetAllMetricSources().SelectMany(x => x.GetMetricMembers()); 
     public static IEnumerable<MetricSpecifier> GetMetricSpecifiers(this ITypeData td) =>
         td.GetMetricMembers().Select(x => new MetricSpecifier(x));
 }

--- a/OpenTap.Metrics/Settings/MetricSpecifier.cs
+++ b/OpenTap.Metrics/Settings/MetricSpecifier.cs
@@ -75,7 +75,7 @@ public class MetricSpecifier : IEquatable<MetricSpecifier>
     private MergedMetricInfo _mergedMetricInfo => _cache.GetOrAdd(this, static x =>
     {
         var mmi = new MergedMetricInfo();
-        var metricSpecifiers = TypeData.GetDerivedTypes<IMetricSource>().SelectMany(src => src.GetMetricMembers())
+        var metricSpecifiers = MetricMemberHelpers.GetAllMetricMembers()
             .Where(x2 => new MetricSpecifier(x2).Equals(x))
             .ToArray();
         foreach (var g in metricSpecifiers)

--- a/OpenTap.Metrics/Settings/MetricsSettingsItem.cs
+++ b/OpenTap.Metrics/Settings/MetricsSettingsItem.cs
@@ -169,9 +169,9 @@ public class MetricsSettingsItem : ValidatingObject, IMetricsSettingsItem
                 var sources = CurrentSources;
                 if (string.IsNullOrWhiteSpace(sources))
                 {
-                    var availableFrom = TypeData.GetDerivedTypes<IMetricSource>()
+                    var availableFrom = TypeData.GetDerivedTypes<IResource>()
+                        .Where(x => x.CanCreateInstance)
                         .Where(m => m.GetMetricSpecifiers().Contains(Specifier))
-                        .Where(td => td.DescendsTo(typeof(IResource)))
                         .Select(td => td.GetDisplayAttribute().GetFullName())
                         .ToArray();
                     if (availableFrom.Any())


### PR DESCRIPTION
This aligns the Metric settings page behavior with the MetricManager behavior, which always considers an IResource a metric producer, regardless of the IMetricSource interface

Closes #115 