### PR TITLE
141 Faulty Asset Provider Protection: fix

### DIFF
--- a/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
+++ b/OpenTap.Metrics.UnitTest/DynamicMetricTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using OpenTap.Metrics.AssetDiscovery;
 using OpenTap.Metrics.Settings;
 
 namespace OpenTap.Metrics.UnitTest;
@@ -298,5 +299,22 @@ public class DynamicMetricTests
         Assert.That(metrics.Length, Is.GreaterThan(0));
         Assert.That(errors1, Is.Empty);
         Assert.That(errors2, Is.Empty);
+    }
+}
+
+public class TestAssetProvider : IAssetDiscoveryProvider
+{
+    public string Name { get; set; } = "Test";
+
+    public double Priority { get; } = 10;
+
+    public TestAssetProvider()
+    {
+        throw new Exception("This fails");
+    }
+
+    public DiscoveryResult DiscoverAssets()
+    {
+        return new DiscoveryResult();
     }
 }

--- a/OpenTap.Metrics/AssetDiscovery/AssetDiscoverySettings.cs
+++ b/OpenTap.Metrics/AssetDiscovery/AssetDiscoverySettings.cs
@@ -1,19 +1,34 @@
+using System;
 using System.Linq;
+using System.Reflection;
 
 namespace OpenTap.Metrics.AssetDiscovery;
 
 [Display("Asset Discovery", "List of asset discovery providers to use.")]
 public class AssetDiscoverySettings : ComponentSettingsList<AssetDiscoverySettings, IAssetDiscoveryProvider>
 {
+    private static TraceSource log = Log.CreateSource("Asset Discovery Settings");
+    
     public override void Initialize()
     {
         // By default, add all available asset discovery providers.
         // this will be overridden by the deserializer, if we have a saved configuration.
-        var assetDiscoveryProviders = TypeData.GetDerivedTypes<IAssetDiscoveryProvider>().Where(x => x.CanCreateInstance)
-            .Select(x => x.CreateInstance() as IAssetDiscoveryProvider);
-        foreach (var provider in assetDiscoveryProviders)
+        
+        foreach (var providerType in TypeData.GetDerivedTypes<IAssetDiscoveryProvider>().Where(x => x.CanCreateInstance))
         {
-            Add(provider);
+            try
+            {
+                var provider = (IAssetDiscoveryProvider)providerType.CreateInstance();
+                Add(provider);
+            }
+            catch (Exception e0)
+            {
+                // log
+                Exception e = (e0 as TargetInvocationException)?.InnerException ?? e0;
+                log.Error($"Asset provider {providerType} threw an exception: {e.Message}.");
+                log.Debug(e);
+
+            }
         }
     }
 }

--- a/OpenTap.Metrics/OpenTap.Metrics.csproj
+++ b/OpenTap.Metrics/OpenTap.Metrics.csproj
@@ -37,11 +37,6 @@
     <InternalsVisibleTo Include="OpenTap.Metrics.UnitTest" />
   </ItemGroup>
 
-
-  <ItemGroup Condition="$(OS) == 'UNIX' AND '$(Configuration)' == 'Debug'">
-    <OpenTapPackageReference Include="TUI" version="1"/>
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageReference Include="OpenTAP" Version="$(OpenTapVersion)" />


### PR DESCRIPTION
- Fixed issue by catching the exception.
- Added some testing by creating a faulty provider as part of the tests.
- Removed TUI from the configuration as Editor for OpenTAP 9.30 works on all platforms.

Close #141