### PR TITLE
MetricManager: publish metrics from discovered assets

### DIFF
--- a/.gitversion
+++ b/.gitversion
@@ -1,3 +1,3 @@
-version = 1.0.4
+version = 1.1.0
 beta branch = main
 release branch = release[0-9x]*

--- a/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
+++ b/OpenTap.Metrics.UnitTest/MetricManagerTest.cs
@@ -77,6 +77,67 @@ public class FullMetricSource : IMetricSource
 [TestFixture]
 public class MetricManagerTest
 {
+    public class MetricAssetDiscoverer : AssetDiscoveryProvider
+    {
+        public MetricAssetDiscoverer() { Name = "Test Asset Discoverer"; }
+        public class TestAsset(int id) : IAsset, IMetricSource, IOnPollMetricsCallback
+        {
+            public string Manufacturer => "Keysight";
+            public string Model => "Dummy";
+            public string AssetIdentifier => $"Dummy:{id}";
+
+            [Metric("In Use", "Test Asset Metrics", MetricKind.Poll, DefaultEnabled = true, DefaultPollRate = 60)]
+            public double InUse { get; set; } = 1;
+
+            [Metric("Not Added", "Test Asset Metrics", MetricKind.Poll, DefaultEnabled = false, DefaultPollRate = 60)]
+            public double NotAdded { get; set; } = 2;
+
+            public void OnPollMetrics(IEnumerable<MetricInfo> metrics)
+            {
+                InUse *= id;
+            }
+        }
+
+        internal static readonly TestAsset[] _assets = [new TestAsset(1), new TestAsset(2)];
+        public override DiscoveryResult DiscoverAssets()
+        {
+            return new DiscoveryResult()
+            {
+                IsSuccess = true,
+                Assets = _assets,
+            };
+        }
+    }
+
+    [Test]
+    public void TestDiscoveredAssetMetrics()
+    {
+        var assets = AssetDiscoveryManager.DiscoverAllAssets();
+
+        var enabledMetrics = MetricsSettings.Current.OfType<MetricsSettingsItem>().Where(x => x.IsEnabled).ToArray();
+        var a1 = enabledMetrics.FirstOrDefault(m => m.Name == "In Use");
+        Assert.That(a1, Is.Not.Null);
+        var a2 = enabledMetrics.FirstOrDefault(m => m.Name == "Not Added");
+        Assert.That(a2, Is.Null);
+
+        var poll1 = MetricManager.PollMetrics(a1.Metrics).ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(poll1, Has.Length.EqualTo(2));
+            /* OnPoll sets value *= id */
+            Assert.That(poll1[0].Value, Is.EqualTo(1));
+            Assert.That(poll1[1].Value, Is.EqualTo(2));
+        });
+        var poll2 = MetricManager.PollMetrics(a1.Metrics).ToArray();
+        Assert.Multiple(() =>
+        {
+            Assert.That(poll2, Has.Length.EqualTo(2));
+            /* OnPoll sets value *= id */
+            Assert.That(poll2[0].Value, Is.EqualTo(1));
+            Assert.That(poll2[1].Value, Is.EqualTo(4));
+        });
+    }
+
     public class IdleResultTestInstrument : Instrument, IOnPollMetricsCallback
     {
         public IdleResultTestInstrument()

--- a/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
+++ b/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
@@ -31,36 +31,20 @@ public static class AssetDiscoveryManager
     }
 
 
+    internal static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> GetCachedAssets() => new(_cachedAssets);
+
     /* Asset providers can be really slow, so it is useful internally to have a mechanism for getting somewhat recent assets.
      * The alternative would be a massive slowdown since this path is triggered by TypeData searchers */
-    private static readonly TimeSpan CacheStaleTime = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan CacheStaleTime = TimeSpan.FromSeconds(2);
     internal static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> GetRecentAssets()
     {
         if (_cachedAssets == null || DateTime.Now - _lastPoll > CacheStaleTime)
             DiscoverAllAssets();
-        return new Dictionary<IAssetDiscoveryProvider, DiscoveryResult>(_cachedAssets);
+        return new(_cachedAssets);
     }
 
     private static DateTime _lastPoll = DateTime.MinValue;
-    private static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> _cachedAssets = null;
-
-    internal static Task<T> StartAwaitableTapThread<T>(Func<T> action)
-    {
-        var result = new TaskCompletionSource<T>();
-        TapThread.Start(() =>
-        {
-            try
-            {
-                result.SetResult(action());
-            }
-            catch (Exception inner)
-            {
-                result.SetException(inner);
-            }
-        });
-        return result.Task;
-    }
-
+    private static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> _cachedAssets = [];
 
     /// <summary>
     /// Returns all discovered assets from all available providers.
@@ -73,7 +57,7 @@ public static class AssetDiscoveryManager
             /* lock on lockObj to wait for the other thread to finish */
             lock (lockObj)
             {
-                return new Dictionary<IAssetDiscoveryProvider, DiscoveryResult>(_cachedAssets);
+                return new(_cachedAssets);
             }
         }
 
@@ -90,7 +74,7 @@ public static class AssetDiscoveryManager
                 // If the provider is already in the list, the Discover query timed out in the last time.
                 // In that case, we should wait for the previous query to complete instead of starting a new one.
                 if (_workQueue.ContainsKey(provider) == false)
-                    _workQueue.TryAdd(provider, StartAwaitableTapThread(() => DiscoverAssets(provider)));
+                    _workQueue.TryAdd(provider, ReflectionHelper.StartAwaitableTapThread(() => DiscoverAssets(provider)));
             }
 
             Task.WaitAll(_workQueue.Values.ToArray<Task>(), timeout);
@@ -117,10 +101,10 @@ public static class AssetDiscoveryManager
                 }
             }
 
-            _cachedAssets = assets;
             _lastPoll = DateTime.Now;
+            _cachedAssets = assets;
             /* return the result in a new dictionary to ensure callers can safely mutate the result without affecting users of the cache. */
-            return new Dictionary<IAssetDiscoveryProvider, DiscoveryResult>(assets);
+            return new(_cachedAssets);
         }
         finally
         {

--- a/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
+++ b/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
@@ -38,7 +38,7 @@ public static class AssetDiscoveryManager
     {
         if (_cachedAssets == null || DateTime.Now - _lastPoll > CacheStaleTime)
             DiscoverAllAssets();
-        return _cachedAssets;
+        return new Dictionary<IAssetDiscoveryProvider, DiscoveryResult>(_cachedAssets);
     }
 
     private static DateTime _lastPoll = DateTime.MinValue;
@@ -73,7 +73,7 @@ public static class AssetDiscoveryManager
             /* lock on lockObj to wait for the other thread to finish */
             lock (lockObj)
             {
-                return _cachedAssets;
+                return new Dictionary<IAssetDiscoveryProvider, DiscoveryResult>(_cachedAssets);
             }
         }
 
@@ -119,7 +119,8 @@ public static class AssetDiscoveryManager
 
             _cachedAssets = assets;
             _lastPoll = DateTime.Now;
-            return assets;
+            /* return the result in a new dictionary to ensure callers can safely mutate the result without affecting users of the cache. */
+            return new Dictionary<IAssetDiscoveryProvider, DiscoveryResult>(assets);
         }
         finally
         {

--- a/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
+++ b/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
@@ -33,17 +33,6 @@ public static class AssetDiscoveryManager
 
     internal static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> GetCachedAssets() => new(_cachedAssets);
 
-    /* Asset providers can be really slow, so it is useful internally to have a mechanism for getting somewhat recent assets.
-     * The alternative would be a massive slowdown since this path is triggered by TypeData searchers */
-    private static readonly TimeSpan CacheStaleTime = TimeSpan.FromSeconds(2);
-    internal static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> GetRecentAssets()
-    {
-        if (_cachedAssets == null || DateTime.Now - _lastPoll > CacheStaleTime)
-            DiscoverAllAssets();
-        return new(_cachedAssets);
-    }
-
-    private static DateTime _lastPoll = DateTime.MinValue;
     private static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> _cachedAssets = [];
 
     /// <summary>
@@ -101,7 +90,6 @@ public static class AssetDiscoveryManager
                 }
             }
 
-            _lastPoll = DateTime.Now;
             _cachedAssets = assets;
             /* return the result in a new dictionary to ensure callers can safely mutate the result without affecting users of the cache. */
             return new(_cachedAssets);

--- a/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
+++ b/OpenTap.Metrics/AssetDiscovery/AssetDiscoveryManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace OpenTap.Metrics.AssetDiscovery;
@@ -29,12 +30,54 @@ public static class AssetDiscoveryManager
         }
     }
 
+
+    /* Asset providers can be really slow, so it is useful internally to have a mechanism for getting somewhat recent assets.
+     * The alternative would be a massive slowdown since this path is triggered by TypeData searchers */
+    private static readonly TimeSpan CacheStaleTime = TimeSpan.FromSeconds(3);
+    internal static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> GetRecentAssets()
+    {
+        if (_cachedAssets == null || DateTime.Now - _lastPoll > CacheStaleTime)
+            DiscoverAllAssets();
+        return _cachedAssets;
+    }
+
+    private static DateTime _lastPoll = DateTime.MinValue;
+    private static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> _cachedAssets = null;
+
+    internal static Task<T> StartAwaitableTapThread<T>(Func<T> action)
+    {
+        var result = new TaskCompletionSource<T>();
+        TapThread.Start(() =>
+        {
+            try
+            {
+                result.SetResult(action());
+            }
+            catch (Exception inner)
+            {
+                result.SetException(inner);
+            }
+        });
+        return result.Task;
+    }
+
+
     /// <summary>
     /// Returns all discovered assets from all available providers.
     /// </summary>
     public static Dictionary<IAssetDiscoveryProvider, DiscoveryResult> DiscoverAllAssets()
     {
-        lock (lockObj)
+        /* if another thread is holding lockObj, we should just return that result instead of recomputing it. */
+        if (!Monitor.TryEnter(lockObj, 0)) 
+        {
+            /* lock on lockObj to wait for the other thread to finish */
+            lock (lockObj)
+            {
+                return _cachedAssets;
+            }
+        }
+
+        try
         {
             TimeSpan timeout = TimeSpan.FromSeconds(10);
             Dictionary<IAssetDiscoveryProvider, DiscoveryResult> assets =
@@ -47,7 +90,7 @@ public static class AssetDiscoveryManager
                 // If the provider is already in the list, the Discover query timed out in the last time.
                 // In that case, we should wait for the previous query to complete instead of starting a new one.
                 if (_workQueue.ContainsKey(provider) == false)
-                    _workQueue.TryAdd(provider, Task.Run(() => DiscoverAssets(provider)));
+                    _workQueue.TryAdd(provider, StartAwaitableTapThread(() => DiscoverAssets(provider)));
             }
 
             Task.WaitAll(_workQueue.Values.ToArray<Task>(), timeout);
@@ -74,7 +117,13 @@ public static class AssetDiscoveryManager
                 }
             }
 
+            _cachedAssets = assets;
+            _lastPoll = DateTime.Now;
             return assets;
+        }
+        finally
+        {
+            Monitor.Exit(lockObj);
         }
     }
 

--- a/OpenTap.Metrics/AssetDiscovery/IAssetDiscoveryProvider.cs
+++ b/OpenTap.Metrics/AssetDiscovery/IAssetDiscoveryProvider.cs
@@ -99,7 +99,7 @@ public class DiscoveryResult
 /// Interface for an object that represents an asset. 
 /// Instruments and other Resources should implement this interface if they want to attach metrics to the asset.
 /// </summary>
-public interface IAsset
+public interface IAsset : ITapPlugin
 {
     /// <summary>
     /// The manufacturer of the asset. E.g. "Keysight". 

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -16,6 +16,18 @@ namespace OpenTap.Metrics;
 /// </summary>
 public static class MetricManager
 {
+    class ReferenceEqualsEqualityComparer : IEqualityComparer<object>
+    {
+        public new bool Equals(object x, object y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        public int GetHashCode(object obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
     /// <summary>
     /// NOTE: This method only exists to clear between unit tests.
     /// This should never be used
@@ -94,7 +106,7 @@ public static class MetricManager
 
         var assets = AssetDiscoveryManager.DiscoverAllAssets().SelectMany(result => result.Value.Assets).ToArray();
 
-        foreach (var metricSource in producers.Concat(instruments).Concat(duts).Concat(assets))
+        foreach (var metricSource in producers.Concat(instruments).Concat(duts).Concat(assets).Distinct(new ReferenceEqualsEqualityComparer()))
         {
 
             var type1 = TypeData.GetTypeData(metricSource);

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -104,7 +104,7 @@ public static class MetricManager
         IEnumerable<object> instruments = ComponentSettings.GetCurrentFromCache(typeof(InstrumentSettings)) as InstrumentSettings ?? [];
         IEnumerable<object> duts = ComponentSettings.GetCurrentFromCache(typeof(DutSettings)) as DutSettings ?? [];
 
-        var assets = AssetDiscoveryManager.DiscoverAllAssets().SelectMany(result => result.Value.Assets).ToArray();
+        var assets = AssetDiscoveryManager.GetRecentAssets().SelectMany(result => result.Value.Assets).ToArray();
 
         foreach (var metricSource in producers.Concat(instruments).Concat(duts).Concat(assets).Distinct(new ReferenceEqualsEqualityComparer()))
         {

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -69,10 +69,7 @@ public static class MetricManager
 
     /// <summary> Get information about the metrics available to query. </summary>
     /// <returns></returns>
-    public static IEnumerable<MetricInfo> GetMetricInfos() => GetMetricInfos(false);
-
-    internal static IEnumerable<MetricInfo> GetMetricInfosCarefully() => GetMetricInfos(true);
-    private static IEnumerable<MetricInfo> GetMetricInfos(bool cautious)
+    public static IEnumerable<MetricInfo> GetMetricInfos()
     {
         var types = TypeData.GetDerivedTypes<IMetricSource>().Where(x => x.CanCreateInstance && !x.DescendsTo(TypeData.FromType(typeof(IAsset))));
         List<object> producers = new List<object>();
@@ -107,8 +104,8 @@ public static class MetricManager
         IEnumerable<object> instruments = ComponentSettings.GetCurrentFromCache(typeof(InstrumentSettings)) as InstrumentSettings ?? [];
         IEnumerable<object> duts = ComponentSettings.GetCurrentFromCache(typeof(DutSettings)) as DutSettings ?? [];
 
-        /* in some contexts, calling this function will deadlock. If the cautious flag is set, refuse to call DiscoverAssets() and use a cache instead if available */
-        var assets = (cautious ? AssetDiscoveryManager.GetCachedAssets() : AssetDiscoveryManager.GetRecentAssets()).SelectMany(result => result.Value.Assets).ToArray();
+        /* Calling DiscoverAssets() would be an unexpected side effect from GetMetricInfos. Always rely on assets being populated in advance. */
+        var assets = AssetDiscoveryManager.GetCachedAssets().SelectMany(x => x.Value.Assets).Cast<object>();
 
         foreach (var metricSource in producers.Concat(instruments).Concat(duts).Concat(assets).Distinct(new ReferenceEqualsEqualityComparer()))
         {

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -69,7 +69,10 @@ public static class MetricManager
 
     /// <summary> Get information about the metrics available to query. </summary>
     /// <returns></returns>
-    public static IEnumerable<MetricInfo> GetMetricInfos()
+    public static IEnumerable<MetricInfo> GetMetricInfos() => GetMetricInfos(false);
+
+    internal static IEnumerable<MetricInfo> GetMetricInfosCarefully() => GetMetricInfos(true);
+    private static IEnumerable<MetricInfo> GetMetricInfos(bool cautious)
     {
         var types = TypeData.GetDerivedTypes<IMetricSource>().Where(x => x.CanCreateInstance && !x.DescendsTo(TypeData.FromType(typeof(IAsset))));
         List<object> producers = new List<object>();
@@ -104,7 +107,8 @@ public static class MetricManager
         IEnumerable<object> instruments = ComponentSettings.GetCurrentFromCache(typeof(InstrumentSettings)) as InstrumentSettings ?? [];
         IEnumerable<object> duts = ComponentSettings.GetCurrentFromCache(typeof(DutSettings)) as DutSettings ?? [];
 
-        var assets = AssetDiscoveryManager.GetRecentAssets().SelectMany(result => result.Value.Assets).ToArray();
+        /* in some contexts, calling this function will deadlock. If the cautious flag is set, refuse to call DiscoverAssets() and use a cache instead if available */
+        var assets = (cautious ? AssetDiscoveryManager.GetCachedAssets() : AssetDiscoveryManager.GetRecentAssets()).SelectMany(result => result.Value.Assets).ToArray();
 
         foreach (var metricSource in producers.Concat(instruments).Concat(duts).Concat(assets).Distinct(new ReferenceEqualsEqualityComparer()))
         {

--- a/OpenTap.Metrics/MetricManager.cs
+++ b/OpenTap.Metrics/MetricManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using OpenTap.Metrics.AssetDiscovery;
 
 namespace OpenTap.Metrics;
 
@@ -58,7 +59,7 @@ public static class MetricManager
     /// <returns></returns>
     public static IEnumerable<MetricInfo> GetMetricInfos()
     {
-        var types = TypeData.GetDerivedTypes<IMetricSource>().Where(x => x.CanCreateInstance);
+        var types = TypeData.GetDerivedTypes<IMetricSource>().Where(x => x.CanCreateInstance && !x.DescendsTo(TypeData.FromType(typeof(IAsset))));
         List<object> producers = new List<object>();
         foreach (var type in types)
         {
@@ -88,10 +89,12 @@ public static class MetricManager
 
         // fetching ComponentSettings directly can lead to deadlocks because this function is called from a TypeData Searcher.
         // Rely on cached component settings instead.
-        IEnumerable<IResource> instruments = ComponentSettings.GetCurrentFromCache(typeof(InstrumentSettings)) as InstrumentSettings ?? [];
-        IEnumerable<IResource> duts = ComponentSettings.GetCurrentFromCache(typeof(DutSettings)) as DutSettings ?? [];
+        IEnumerable<object> instruments = ComponentSettings.GetCurrentFromCache(typeof(InstrumentSettings)) as InstrumentSettings ?? [];
+        IEnumerable<object> duts = ComponentSettings.GetCurrentFromCache(typeof(DutSettings)) as DutSettings ?? [];
 
-        foreach (var metricSource in producers.Concat(instruments).Concat(duts))
+        var assets = AssetDiscoveryManager.DiscoverAllAssets().SelectMany(result => result.Value.Assets).ToArray();
+
+        foreach (var metricSource in producers.Concat(instruments).Concat(duts).Concat(assets))
         {
 
             var type1 = TypeData.GetTypeData(metricSource);

--- a/OpenTap.Metrics/ReflectionHelper.cs
+++ b/OpenTap.Metrics/ReflectionHelper.cs
@@ -4,10 +4,11 @@
 // file, you can obtain one at http://mozilla.org/MPL/2.0/.
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace OpenTap.Metrics;
 
-static class ReflectionHelpoer
+static class ReflectionHelper
 {
     /// <summary>
     /// Returns true if a type is numeric.
@@ -51,6 +52,23 @@ static class ReflectionHelpoer
     public static bool IsNumeric(this ITypeData t)
     {
         return t.AsTypeData()?.Type.IsNumeric() == true;
+    }
+
+    internal static Task<T> StartAwaitableTapThread<T>(Func<T> action)
+    {
+        var result = new TaskCompletionSource<T>();
+        TapThread.Start(() =>
+        {
+            try
+            {
+                result.SetResult(action());
+            }
+            catch (Exception inner)
+            {
+                result.SetException(inner);
+            }
+        });
+        return result.Task;
     }
 
     struct OnceLogToken

--- a/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
+++ b/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
@@ -26,7 +26,7 @@ public class MetricInfoTypeDataSearcher : ITypeDataSearcher, ITypeDataSourceProv
                 getting = true;
                 try
                 {
-                    return MetricManager.GetMetricInfos()
+                    return MetricManager.GetMetricInfosCarefully()
                         .Select(x => new MetricSpecifier(x.Member))
                         .Distinct()
                         .ToArray();

--- a/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
+++ b/OpenTap.Metrics/Settings/MetricInfoTypeDataSearcher.cs
@@ -1,12 +1,8 @@
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System;
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
-using System.Threading;
 
 namespace OpenTap.Metrics.Settings;
 
@@ -26,7 +22,7 @@ public class MetricInfoTypeDataSearcher : ITypeDataSearcher, ITypeDataSourceProv
                 getting = true;
                 try
                 {
-                    return MetricManager.GetMetricInfosCarefully()
+                    return MetricManager.GetMetricInfos()
                         .Select(x => new MetricSpecifier(x.Member))
                         .Distinct()
                         .ToArray();

--- a/OpenTap.Metrics/Settings/MetricMemberHelpers.cs
+++ b/OpenTap.Metrics/Settings/MetricMemberHelpers.cs
@@ -1,6 +1,6 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using OpenTap.Metrics.AssetDiscovery;
 
 namespace OpenTap.Metrics.Settings;
 
@@ -17,10 +17,22 @@ internal static class MetricMemberHelpers
     public static IEnumerable<IMemberData> GetMetricMembers(this ITypeData td) =>
         td.GetMembers().Where(mem => mem.HasAttribute<MetricAttribute>());
 
+    private static bool IsConcrete(ITypeData td)
+    {
+        var td2 = td.AsTypeData();
+        /* assume non-TypeData are concrete. */
+        if (td2 == null) return true;
+        return !(td2.Type.IsInterface || td2.Type.IsAbstract);
+    }
+    
     public static IEnumerable<ITypeData> GetAllMetricSources() =>
         TypeData.GetDerivedTypes<IMetricSource>()
             .Concat(TypeData.GetDerivedTypes<IResource>())
-            .Where(x => x.CanCreateInstance);
+            .Where(x => x.CanCreateInstance)
+            /* no need to filter IAsset implementations based on being able to create instances.
+             The instances are created by AssetProvider implementations. */
+            .Concat(TypeData.GetDerivedTypes<IAsset>().Where(IsConcrete))
+            .Distinct();
 
     public static IEnumerable<IMemberData> GetAllMetricMembers() => GetAllMetricSources().SelectMany(x => x.GetMetricMembers()); 
     public static IEnumerable<MetricSpecifier> GetMetricSpecifiers(this ITypeData td) =>


### PR DESCRIPTION
This updates the metrics implementation to consider discovered assets as potential metrics producers, similars to how DUTs and Instruments are currently handled.

There are a few problems however, so the feature comes with some caveats:

1. GetMetricInfos() is called in some contexts where it is extremely easy to deadlock. In that case it is not safe to do asset discovery, so an internal overload was added to skip the asset check
2. Checking assets can be extremely slow, and metrics are sometimes checked in a tight loop, so a simple time guarded cache was added for quick metric retrieval in the average case.
3. Concurrent asset discovery calls were coalesced to return the same result instead of duplicating work.

Closes #144 